### PR TITLE
Handle model data from API endpoint

### DIFF
--- a/src/components/Moderation/Moderation.tsx
+++ b/src/components/Moderation/Moderation.tsx
@@ -1,5 +1,3 @@
-import type { CTypeData } from '../../models/ctype';
-
 import { MouseEvent, useCallback, useEffect, useState } from 'react';
 
 import styles from './Moderation.module.css';
@@ -10,9 +8,15 @@ import { sessionHeader } from '../../utilities/sessionHeader';
 import { exceptionToError } from '../../utilities/exceptionToError';
 
 import { apiWindow, getCompatibleExtensions, getSession } from './session';
-import { useCTypes } from './useCTypes';
+import { APICTypeData, useCTypes } from './useCTypes';
 
-function CType({ sessionId, cType }: { sessionId: string; cType: CTypeData }) {
+function CType({
+  sessionId,
+  cType,
+}: {
+  sessionId: string;
+  cType: APICTypeData;
+}) {
   const {
     id,
     createdAt,
@@ -51,9 +55,7 @@ function CType({ sessionId, cType }: { sessionId: string; cType: CTypeData }) {
   }, [id, isHidden, sessionId]);
 
   const propertyNames = Object.keys(properties).join(', ');
-  const tagNames = tags
-    ?.map(({ dataValues: { tagName } }) => `#${tagName}`)
-    .join(', ');
+  const tagNames = tags?.map(({ tagName }) => `#${tagName}`).join(', ');
 
   return (
     <tr className={styles.tableRow}>

--- a/src/components/Moderation/useCTypes.ts
+++ b/src/components/Moderation/useCTypes.ts
@@ -1,12 +1,18 @@
 import type { CTypeData } from '../../models/ctype';
 
+import type { TagData } from '../../models/tag';
+
 import { useCallback, useEffect, useState } from 'react';
 
 import { sessionHeader } from '../../utilities/sessionHeader';
 import { paths } from '../../paths';
 
+export interface APICTypeData extends Omit<CTypeData, 'tags'> {
+  tags?: TagData[];
+}
+
 export function useCTypes(sessionId: string | undefined) {
-  const [cTypes, setCTypes] = useState<CTypeData[]>([]);
+  const [cTypes, setCTypes] = useState<APICTypeData[]>([]);
 
   const fetchBefore = useCallback(
     async (before?: Date) => {
@@ -29,7 +35,7 @@ export function useCTypes(sessionId: string | undefined) {
         throw new Error('Unable to fetch CTypes');
       }
 
-      const newCTypes: CTypeData[] = await response.json();
+      const newCTypes: APICTypeData[] = await response.json();
       setCTypes((existingCTypes) => {
         const lastKnownId = existingCTypes.at(-1)?.id;
         while (newCTypes.some(({ id }) => id === lastKnownId)) {

--- a/src/pages/moderation/ctype.ts
+++ b/src/pages/moderation/ctype.ts
@@ -19,16 +19,14 @@ export async function get({ request, url }: APIContext) {
 
     const before = url.searchParams.get('before');
 
-    const cTypes = (
-      await CType.findAll({
-        where: {
-          createdAt: { [Op.lte]: before ? new Date(before) : new Date() },
-        },
-        order: [['createdAt', 'DESC']],
-        include: 'tags',
-        limit: 20,
-      })
-    ).map(({ dataValues }) => dataValues);
+    const cTypes = await CType.findAll({
+      where: {
+        createdAt: { [Op.lte]: before ? new Date(before) : new Date() },
+      },
+      order: [['createdAt', 'DESC']],
+      include: 'tags',
+      limit: 20,
+    });
 
     return new Response(JSON.stringify(cTypes), {
       headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
Fixes https://github.com/KILTprotocol/ticket/issues/2900

Calling `JSON.stringify` on model instances also calls sequelize's `toJSON()`on them, and only the `dataValues` object is serialized.