### PR TITLE
Pagination bugfix

### DIFF
--- a/src/utilities/paginate.ts
+++ b/src/utilities/paginate.ts
@@ -13,7 +13,7 @@ export async function paginate(
 
   const isHomePage = !page || !Number.isInteger(Number(page));
 
-  const total = await CType.count({ where, include });
+  const total = await CType.count({ where });
   const lastPage = Math.floor(total / pageLimit);
 
   const currentPage = isHomePage ? lastPage : Number(page);


### PR DESCRIPTION
Fixes https://github.com/KILTprotocol/ticket/issues/2903

Including `include` in the count method will count the number of associations rather than the number of records