### PR TITLE
Start scan from next block

### DIFF
--- a/src/utilities/scanAttestations.test.ts
+++ b/src/utilities/scanAttestations.test.ts
@@ -158,7 +158,7 @@ describe('scanAttestations', () => {
       order: [['createdAt', 'DESC']],
     });
 
-    const expectedFromBlock = Number(latestAttestation?.dataValues.block);
+    const expectedFromBlock = Number(latestAttestation?.dataValues.block) + 1;
 
     vi.mocked(subScanEventGenerator).mockImplementation(async function* () {
       // yield nothing

--- a/src/utilities/scanAttestations.ts
+++ b/src/utilities/scanAttestations.ts
@@ -17,7 +17,7 @@ export async function scanAttestations() {
     order: [['createdAt', 'DESC']],
   });
   const fromBlock = latestAttestation
-    ? Number(latestAttestation.dataValues.block)
+    ? Number(latestAttestation.dataValues.block) + 1
     : 0;
 
   const eventGenerator = subScanEventGenerator(

--- a/src/utilities/scanCTypes.test.ts
+++ b/src/utilities/scanCTypes.test.ts
@@ -106,7 +106,7 @@ describe('scanCTypes', () => {
       },
     });
 
-    const expectedFromBlock = Number(latestCType?.dataValues.block);
+    const expectedFromBlock = Number(latestCType?.dataValues.block) + 1;
 
     vi.mocked(subScanEventGenerator).mockImplementation(async function* () {
       // yield nothing

--- a/src/utilities/scanCTypes.ts
+++ b/src/utilities/scanCTypes.ts
@@ -22,7 +22,7 @@ export async function scanCTypes() {
     },
   });
 
-  const fromBlock = latestCType ? Number(latestCType.dataValues.block) : 0;
+  const fromBlock = latestCType ? Number(latestCType.dataValues.block) + 1 : 0;
   const eventGenerator = subScanEventGenerator(
     'ctype',
     'CTypeCreated',


### PR DESCRIPTION
Avoids querying and upserting the same cType/attestation every 10 minutes.