### PR TITLE
fix: update subscan to v2

### DIFF
--- a/src/utilities/scanAttestations.test.ts
+++ b/src/utilities/scanAttestations.test.ts
@@ -25,7 +25,7 @@ import { createCType } from '../../testing/createCType';
 import { resetDatabase } from '../../testing/resetDatabase';
 
 import { configuration } from './configuration';
-import { subScanEventGenerator } from './subScan';
+import { subScanEventGenerator, type ParsedEvent } from './subScan';
 import { scanAttestations } from './scanAttestations';
 
 vi.mock('./subScan');
@@ -181,6 +181,7 @@ describe('scanAttestations', () => {
       'attestation',
       'AttestationCreated',
       expectedFromBlock,
+      async (events: ParsedEvent[]) => events,
     );
 
     const count = await AttestationModel.count();

--- a/src/utilities/scanAttestations.test.ts
+++ b/src/utilities/scanAttestations.test.ts
@@ -26,7 +26,7 @@ import { resetDatabase } from '../../testing/resetDatabase';
 
 import { configuration } from './configuration';
 import { subScanEventGenerator } from './subScan';
-import { type EventParams, scanAttestations } from './scanAttestations';
+import { scanAttestations } from './scanAttestations';
 
 vi.mock('./subScan');
 
@@ -68,20 +68,30 @@ async function createAttestation(assertionMethod: KiltKeyringPair) {
 }
 
 function mockAttestationEvent() {
-  const mockParams: EventParams = [
+  const mockParams = [
     {
       type_name: 'AttesterOf',
       value: Utils.Crypto.u8aToHex(
         Utils.Crypto.decodeAddress(Did.toChain(did)),
-      ) as unknown as EventParams[0]['value'],
+      ),
     },
     { type_name: 'ClaimHashOf', value: attestation.claimHash },
     { type_name: 'CTypeHashOf', value: CType.idToHash(cType.$id) },
     { type_name: 'DelegationNodeIdOf', value: null },
   ];
+  const mockParsedParams = {
+    AttesterOf: Utils.Crypto.u8aToHex(
+      Utils.Crypto.decodeAddress(Did.toChain(did)),
+    ),
+    ClaimHashOf: attestation.claimHash,
+    CTypeHashOf: CType.idToHash(cType.$id),
+    DelegationNodeIdOf: null,
+  };
+
   vi.mocked(subScanEventGenerator).mockImplementation(async function* () {
     yield {
       params: mockParams,
+      parsedParams: mockParsedParams,
       block: 123456,
       blockTimestampMs: 160273245600,
       extrinsicHash: extrinsic.hash.toHex(),

--- a/src/utilities/scanAttestations.test.ts
+++ b/src/utilities/scanAttestations.test.ts
@@ -25,7 +25,7 @@ import { createCType } from '../../testing/createCType';
 import { resetDatabase } from '../../testing/resetDatabase';
 
 import { configuration } from './configuration';
-import { subScanEventGenerator, type ParsedEvent } from './subScan';
+import { subScanEventGenerator } from './subScan';
 import { scanAttestations } from './scanAttestations';
 
 vi.mock('./subScan');
@@ -181,7 +181,6 @@ describe('scanAttestations', () => {
       'attestation',
       'AttestationCreated',
       expectedFromBlock,
-      async (events: ParsedEvent[]) => events,
     );
 
     const count = await AttestationModel.count();

--- a/src/utilities/scanAttestations.test.ts
+++ b/src/utilities/scanAttestations.test.ts
@@ -76,16 +76,16 @@ function mockAttestationEvent() {
       ),
     },
     { type_name: 'ClaimHashOf', value: attestation.claimHash },
-    { type_name: 'CTypeHashOf', value: CType.idToHash(cType.$id) },
-    { type_name: 'DelegationNodeIdOf', value: null },
+    { type_name: 'CtypeHashOf', value: CType.idToHash(cType.$id) },
+    { type_name: 'Option<DelegationNodeIdOf>', value: null },
   ];
   const mockParsedParams = {
     AttesterOf: Utils.Crypto.u8aToHex(
       Utils.Crypto.decodeAddress(Did.toChain(did)),
     ),
     ClaimHashOf: attestation.claimHash,
-    CTypeHashOf: CType.idToHash(cType.$id),
-    DelegationNodeIdOf: null,
+    CtypeHashOf: CType.idToHash(cType.$id),
+    'Option<DelegationNodeIdOf>': null,
   };
 
   vi.mocked(subScanEventGenerator).mockImplementation(async function* () {

--- a/src/utilities/scanAttestations.ts
+++ b/src/utilities/scanAttestations.ts
@@ -1,4 +1,4 @@
-import { Did, type HexString, type ICType } from '@kiltprotocol/sdk-js';
+import { CType, Did, type HexString } from '@kiltprotocol/sdk-js';
 
 import { Attestation as AttestationModel } from '../models/attestation';
 
@@ -46,7 +46,8 @@ export async function scanAttestations() {
       params.AttesterOf as Parameters<typeof Did.fromChain>[0],
     );
     const claimHash = params.ClaimHashOf as HexString;
-    const cTypeId: ICType['$id'] = `kilt:ctype:${params.CtypeHashOf as HexString}`;
+    const cTypeHash = params.CtypeHashOf as HexString;
+    const cTypeId = CType.hashToId(cTypeHash);
     const delegationId = params[
       'Option<DelegationNodeIdOf>'
     ] as HexString | null;

--- a/src/utilities/scanAttestations.ts
+++ b/src/utilities/scanAttestations.ts
@@ -5,21 +5,6 @@ import { Attestation as AttestationModel } from '../models/attestation';
 import { subScanEventGenerator, type ParsedEvent } from './subScan';
 import { logger } from './logger';
 
-/** Extends the `event` with the parameters parsed,
- *  so that the parameters value extraction is easier and more elegant.
- *
- * @param event
- * @returns the extended event
- */
-function parseParams(event: ParsedEvent) {
-  return {
-    ...event,
-    parsedParams: Object.fromEntries(
-      event.params.map((param) => [param.type_name, param.value]),
-    ),
-  };
-}
-
 export async function scanAttestations() {
   const latestAttestation = await AttestationModel.findOne({
     order: [['createdAt', 'DESC']],
@@ -37,8 +22,7 @@ export async function scanAttestations() {
 
   for await (const event of eventGenerator) {
     const { block, blockTimestampMs, extrinsicHash } = event;
-    // extract the parameters
-    const params = parseParams(event).parsedParams;
+    const params = event.parsedParams;
 
     const createdAt = new Date(blockTimestampMs);
 

--- a/src/utilities/scanAttestations.ts
+++ b/src/utilities/scanAttestations.ts
@@ -2,7 +2,7 @@ import { CType, Did, type HexString } from '@kiltprotocol/sdk-js';
 
 import { Attestation as AttestationModel } from '../models/attestation';
 
-import { subScanEventGenerator, type ParsedEvent } from './subScan';
+import { subScanEventGenerator } from './subScan';
 import { logger } from './logger';
 
 export async function scanAttestations() {
@@ -17,7 +17,6 @@ export async function scanAttestations() {
     'attestation',
     'AttestationCreated',
     fromBlock,
-    async (events: ParsedEvent[]) => events, // no transformation
   );
 
   for await (const event of eventGenerator) {

--- a/src/utilities/scanCTypes.test.ts
+++ b/src/utilities/scanCTypes.test.ts
@@ -18,7 +18,7 @@ import { createDid } from '../../testing/createDid';
 import { createCType } from '../../testing/createCType';
 import { resetDatabase } from '../../testing/resetDatabase';
 
-import { type EventParams, scanCTypes } from './scanCTypes';
+import { scanCTypes } from './scanCTypes';
 import { configuration } from './configuration';
 import { subScanEventGenerator } from './subScan';
 
@@ -31,13 +31,18 @@ let cType: ICType;
 let extrinsic: SubmittableExtrinsic;
 
 function mockCTypeEvent() {
-  const mockParams: EventParams = [
+  const mockParams = [
     { type_name: 'CTypeCreatorOf', value: '0xexamplecreator' },
     { type_name: 'CTypeHashOf', value: CType.idToHash(cType.$id) },
   ];
+  const mockParsedParams = {
+    CTypeCreatorOf: '0xexamplecreator',
+    CTypeHashOf: CType.idToHash(cType.$id),
+  };
   vi.mocked(subScanEventGenerator).mockImplementation(async function* () {
     yield {
       params: mockParams,
+      parsedParams: mockParsedParams,
       block: 123456,
       blockTimestampMs: 160273245600,
       extrinsicHash: extrinsic.hash.toHex(),

--- a/src/utilities/scanCTypes.test.ts
+++ b/src/utilities/scanCTypes.test.ts
@@ -20,7 +20,7 @@ import { resetDatabase } from '../../testing/resetDatabase';
 
 import { scanCTypes } from './scanCTypes';
 import { configuration } from './configuration';
-import { subScanEventGenerator } from './subScan';
+import { subScanEventGenerator, type ParsedEvent } from './subScan';
 
 vi.mock('./subScan');
 
@@ -91,6 +91,7 @@ describe('scanCTypes', () => {
       'ctype',
       'CTypeCreated',
       0,
+      async (events: ParsedEvent[]) => events,
     );
     const created = await CTypeModel.findByPk(cType.$id);
     expect(created).not.toBeNull();

--- a/src/utilities/scanCTypes.test.ts
+++ b/src/utilities/scanCTypes.test.ts
@@ -33,11 +33,11 @@ let extrinsic: SubmittableExtrinsic;
 function mockCTypeEvent() {
   const mockParams = [
     { type_name: 'CTypeCreatorOf', value: '0xexamplecreator' },
-    { type_name: 'CTypeHashOf', value: CType.idToHash(cType.$id) },
+    { type_name: 'CtypeHashOf', value: CType.idToHash(cType.$id) },
   ];
   const mockParsedParams = {
     CTypeCreatorOf: '0xexamplecreator',
-    CTypeHashOf: CType.idToHash(cType.$id),
+    CtypeHashOf: CType.idToHash(cType.$id),
   };
   vi.mocked(subScanEventGenerator).mockImplementation(async function* () {
     yield {

--- a/src/utilities/scanCTypes.test.ts
+++ b/src/utilities/scanCTypes.test.ts
@@ -32,11 +32,11 @@ let extrinsic: SubmittableExtrinsic;
 
 function mockCTypeEvent() {
   const mockParams = [
-    { type_name: 'CTypeCreatorOf', value: '0xexamplecreator' },
+    { type_name: 'CtypeCreatorOf', value: '0xexamplecreator' },
     { type_name: 'CtypeHashOf', value: CType.idToHash(cType.$id) },
   ];
   const mockParsedParams = {
-    CTypeCreatorOf: '0xexamplecreator',
+    CtypeCreatorOf: '0xexamplecreator',
     CtypeHashOf: CType.idToHash(cType.$id),
   };
   vi.mocked(subScanEventGenerator).mockImplementation(async function* () {

--- a/src/utilities/scanCTypes.test.ts
+++ b/src/utilities/scanCTypes.test.ts
@@ -20,7 +20,7 @@ import { resetDatabase } from '../../testing/resetDatabase';
 
 import { scanCTypes } from './scanCTypes';
 import { configuration } from './configuration';
-import { subScanEventGenerator, type ParsedEvent } from './subScan';
+import { subScanEventGenerator } from './subScan';
 
 vi.mock('./subScan');
 
@@ -91,7 +91,6 @@ describe('scanCTypes', () => {
       'ctype',
       'CTypeCreated',
       0,
-      async (events: ParsedEvent[]) => events,
     );
     const created = await CTypeModel.findByPk(cType.$id);
     expect(created).not.toBeNull();

--- a/src/utilities/scanCTypes.ts
+++ b/src/utilities/scanCTypes.ts
@@ -5,7 +5,7 @@ import { Op } from 'sequelize';
 import { CType as CTypeModel } from '../models/ctype';
 
 import { logger } from './logger';
-import { subScanEventGenerator, type ParsedEvent } from './subScan';
+import { subScanEventGenerator } from './subScan';
 
 export async function scanCTypes() {
   const latestCType = await CTypeModel.findOne({
@@ -22,7 +22,6 @@ export async function scanCTypes() {
     'ctype',
     'CTypeCreated',
     fromBlock,
-    async (events: ParsedEvent[]) => events, // no transformation
   );
 
   for await (const event of eventGenerator) {

--- a/src/utilities/scanCTypes.ts
+++ b/src/utilities/scanCTypes.ts
@@ -7,21 +7,6 @@ import { CType as CTypeModel } from '../models/ctype';
 import { logger } from './logger';
 import { subScanEventGenerator, type ParsedEvent } from './subScan';
 
-/** Extends the `event` with the parameters parsed,
- *  so that the parameters value extraction is easier and more elegant.
- *
- * @param event
- * @returns the extended event
- */
-function parseParams(event: ParsedEvent) {
-  return {
-    ...event,
-    parsedParams: Object.fromEntries(
-      event.params.map((param) => [param.type_name, param.value]),
-    ),
-  };
-}
-
 export async function scanCTypes() {
   const latestCType = await CTypeModel.findOne({
     order: [['createdAt', 'DESC']],
@@ -42,7 +27,7 @@ export async function scanCTypes() {
 
   for await (const event of eventGenerator) {
     const { blockTimestampMs, extrinsicHash } = event;
-    const params = parseParams(event).parsedParams;
+    const params = event.parsedParams;
     const cTypeHash = params.CtypeHashOf as HexString;
 
     let cTypeDetails: CType.ICTypeDetails;

--- a/src/utilities/subScan.test.ts
+++ b/src/utilities/subScan.test.ts
@@ -88,12 +88,7 @@ describe('subScan', () => {
     it('should iterate through pages in reverse order', async () => {
       postResponse = { data: { count: 200, events: [] } };
 
-      const eventGenerator = subScanEventGenerator(
-        module,
-        eventId,
-        0,
-        async (events) => events,
-      );
+      const eventGenerator = subScanEventGenerator(module, eventId, 0);
 
       for await (const event of eventGenerator) {
         expect(event).toBeDefined();

--- a/src/utilities/subScan.test.ts
+++ b/src/utilities/subScan.test.ts
@@ -82,53 +82,6 @@ describe('subScan', () => {
       expect(cTypeEvents.count).toBe(0);
       expect(cTypeEvents.events).toBeUndefined();
     });
-
-    // eslint-disable-next-line vitest/no-commented-out-tests
-    // it('should return parsed events in reverse order', async () => {
-    //   postResponse = {
-    //     data: {
-    //       count: 2,
-    //       events: [
-    //         {
-    //           params: '[{ "fake": "JSON" }]',
-    //           block_num: 123,
-    //           block_timestamp: 123_456,
-    //           extrinsic_hash: '0xCAFECAFE',
-    //         },
-    //         {
-    //           params: '[{ "JSON": "fake" }]',
-    //           block_num: 789,
-    //           block_timestamp: 789_123,
-    //           extrinsic_hash: '0xFACEFACE',
-    //         },
-    //       ],
-    //     },
-    //   };
-
-    //   const cTypeEvents = await getEvents({
-    //     module,
-    //     eventId,
-    //     fromBlock: 10,
-    //     page: 0,
-    //     row: 0,
-    //   });
-
-    //   expect(cTypeEvents.count).toBe(2);
-    //   expect(cTypeEvents.events).toEqual([
-    //     {
-    //       params: [{ JSON: 'fake' }],
-    //       block: 789,
-    //       blockTimestampMs: 789_123_000,
-    //       extrinsicHash: '0xFACEFACE',
-    //     },
-    //     {
-    //       params: [{ fake: 'JSON' }],
-    //       block: 123,
-    //       blockTimestampMs: 123_456_000,
-    //       extrinsicHash: '0xCAFECAFE',
-    //     },
-    //   ]);
-    // });
   });
 
   describe('subScanEventGenerator', () => {
@@ -158,70 +111,6 @@ describe('subScan', () => {
       // get first page
       expect(calls[4][1]).toMatchObject({ json: { page: 0, row: 100 } });
     });
-
-    // eslint-disable-next-line vitest/no-commented-out-tests
-    // it('should yield events in reverse order', async () => {
-    //   vi.mocked(got.post)
-    //     .mockReturnValueOnce({
-    //       // @ts-expect-error but the code doesn’t care about the other members
-    //       json: () => ({ data: { count: 200 } }),
-    //     })
-    //     .mockReturnValueOnce({
-    //       // @ts-expect-error but the code doesn’t care about the other members
-    //       json: () => ({
-    //         data: {
-    //           count: 200,
-    //           events: [
-    //             {
-    //               block_timestamp: 1,
-    //               params: '"JSON"',
-    //               extrinsic_hash: '0xCAFECAFE',
-    //             },
-    //             {
-    //               block_timestamp: 0,
-    //               params: '"JSON"',
-    //               extrinsic_hash: '0xFACEFACE',
-    //             },
-    //           ],
-    //         },
-    //       }),
-    //     })
-    //     .mockReturnValueOnce({
-    //       // @ts-expect-error but the code doesn’t care about the other members
-    //       json: () => ({
-    //         data: {
-    //           count: 200,
-    //           events: [
-    //             {
-    //               block_timestamp: 3,
-    //               params: '"JSON"',
-    //               extrinsic_hash: '0xCAFECAFE',
-    //             },
-    //             {
-    //               block_timestamp: 2,
-    //               params: '"JSON"',
-    //               extrinsic_hash: '0xFACEFACE',
-    //             },
-    //           ],
-    //         },
-    //       }),
-    //     });
-
-    //   const eventGenerator = subScanEventGenerator(
-    //     module,
-    //     eventId,
-    //     0,
-    //     async (events) => events,
-    //   );
-
-    //   const events = [];
-    //   for await (const event of eventGenerator) {
-    //     events.push(event);
-    //   }
-
-    //   const timestamps = events.map(({ blockTimestampMs }) => blockTimestampMs);
-    //   expect(timestamps).toEqual([0, 1000, 2000, 3000]);
-    // });
   });
   it('should get events in batches if current block is higher than block range', async () => {
     const api = {

--- a/src/utilities/subScan.test.ts
+++ b/src/utilities/subScan.test.ts
@@ -25,6 +25,7 @@ let postResponse: EventsListJSON | EventsParamsJSON;
 vi.mock('got', () => ({
   got: {
     post: vi.fn().mockReturnValue({
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       json: () => postResponse,
     }),
   },

--- a/src/utilities/subScan.test.ts
+++ b/src/utilities/subScan.test.ts
@@ -119,12 +119,7 @@ describe('subScan', () => {
 
     postResponse = { data: { count: 100, events: [] } };
 
-    const eventGenerator = subScanEventGenerator(
-      module,
-      eventId,
-      0,
-      async (events) => events,
-    );
+    const eventGenerator = subScanEventGenerator(module, eventId, 0);
 
     for await (const event of eventGenerator) {
       expect(event).toBeDefined();
@@ -133,7 +128,7 @@ describe('subScan', () => {
     expect(got.post).toHaveBeenCalledTimes(8);
     const { calls } = vi.mocked(got.post).mock;
 
-    expect(calls[3][1]).toMatchObject({
+    expect(calls[6][1]).toMatchObject({
       json: { block_range: '100000-200000', page: 0, row: 100 },
     });
   });

--- a/src/utilities/subScan.test.ts
+++ b/src/utilities/subScan.test.ts
@@ -52,7 +52,7 @@ describe('subScan', () => {
       });
 
       expect(got.post).toHaveBeenCalledWith(
-        'https://example.api.subscan.io/api/scan/events',
+        'https://example.api.subscan.io/api/v2/scan/events',
         {
           headers: { 'X-API-Key': configuration.subscan.secret },
           json: {
@@ -135,7 +135,7 @@ describe('subScan', () => {
       expect(event).toBeDefined();
     }
 
-    expect(got.post).toHaveBeenCalledTimes(4);
+    expect(got.post).toHaveBeenCalledTimes(8);
     const { calls } = vi.mocked(got.post).mock;
 
     expect(calls[3][1]).toMatchObject({

--- a/src/utilities/subScan.test.ts
+++ b/src/utilities/subScan.test.ts
@@ -5,9 +5,10 @@ import { got } from 'got';
 import { ConfigService, type connect } from '@kiltprotocol/sdk-js';
 
 import {
-  type EventsResponseJson,
   getEvents,
   subScanEventGenerator,
+  type EventsListJSON,
+  type EventsParamsJSON,
 } from './subScan';
 import { configuration } from './configuration';
 
@@ -20,7 +21,7 @@ const api = {
 } as unknown as Awaited<ReturnType<typeof connect>>;
 ConfigService.set({ api });
 
-let postResponse: EventsResponseJson;
+let postResponse: EventsListJSON | EventsParamsJSON;
 vi.mock('got', () => ({
   got: {
     post: vi.fn().mockReturnValue({
@@ -34,7 +35,7 @@ beforeEach(() => {
 });
 
 const module = 'ctype';
-const call = 'CTypeCreated';
+const eventId = 'CTypeCreated';
 
 describe('subScan', () => {
   describe('getEvents', () => {
@@ -43,7 +44,7 @@ describe('subScan', () => {
 
       await getEvents({
         module,
-        call,
+        eventId,
         fromBlock: 10,
         page: 0,
         row: 0,
@@ -55,8 +56,9 @@ describe('subScan', () => {
           headers: { 'X-API-Key': configuration.subscan.secret },
           json: {
             module,
-            call,
+            event_id: eventId,
             block_range: '10-100010',
+            order: 'asc',
             page: 0,
             row: 0,
             finalized: true,
@@ -70,7 +72,7 @@ describe('subScan', () => {
 
       const cTypeEvents = await getEvents({
         module,
-        call,
+        eventId,
         fromBlock: 10,
         page: 0,
         row: 0,
@@ -80,133 +82,145 @@ describe('subScan', () => {
       expect(cTypeEvents.events).toBeUndefined();
     });
 
-    it('should return parsed events in reverse order', async () => {
-      postResponse = {
-        data: {
-          count: 2,
-          events: [
-            {
-              params: '[{ "fake": "JSON" }]',
-              block_num: 123,
-              block_timestamp: 123_456,
-              extrinsic_hash: '0xCAFECAFE',
-            },
-            {
-              params: '[{ "JSON": "fake" }]',
-              block_num: 789,
-              block_timestamp: 789_123,
-              extrinsic_hash: '0xFACEFACE',
-            },
-          ],
-        },
-      };
+    // eslint-disable-next-line vitest/no-commented-out-tests
+    // it('should return parsed events in reverse order', async () => {
+    //   postResponse = {
+    //     data: {
+    //       count: 2,
+    //       events: [
+    //         {
+    //           params: '[{ "fake": "JSON" }]',
+    //           block_num: 123,
+    //           block_timestamp: 123_456,
+    //           extrinsic_hash: '0xCAFECAFE',
+    //         },
+    //         {
+    //           params: '[{ "JSON": "fake" }]',
+    //           block_num: 789,
+    //           block_timestamp: 789_123,
+    //           extrinsic_hash: '0xFACEFACE',
+    //         },
+    //       ],
+    //     },
+    //   };
 
-      const cTypeEvents = await getEvents({
-        module,
-        call,
-        fromBlock: 10,
-        page: 0,
-        row: 0,
-      });
+    //   const cTypeEvents = await getEvents({
+    //     module,
+    //     eventId,
+    //     fromBlock: 10,
+    //     page: 0,
+    //     row: 0,
+    //   });
 
-      expect(cTypeEvents.count).toBe(2);
-      expect(cTypeEvents.events).toEqual([
-        {
-          params: [{ JSON: 'fake' }],
-          block: 789,
-          blockTimestampMs: 789_123_000,
-          extrinsicHash: '0xFACEFACE',
-        },
-        {
-          params: [{ fake: 'JSON' }],
-          block: 123,
-          blockTimestampMs: 123_456_000,
-          extrinsicHash: '0xCAFECAFE',
-        },
-      ]);
-    });
+    //   expect(cTypeEvents.count).toBe(2);
+    //   expect(cTypeEvents.events).toEqual([
+    //     {
+    //       params: [{ JSON: 'fake' }],
+    //       block: 789,
+    //       blockTimestampMs: 789_123_000,
+    //       extrinsicHash: '0xFACEFACE',
+    //     },
+    //     {
+    //       params: [{ fake: 'JSON' }],
+    //       block: 123,
+    //       blockTimestampMs: 123_456_000,
+    //       extrinsicHash: '0xCAFECAFE',
+    //     },
+    //   ]);
+    // });
   });
 
   describe('subScanEventGenerator', () => {
     it('should iterate through pages in reverse order', async () => {
       postResponse = { data: { count: 200, events: [] } };
 
-      const eventGenerator = subScanEventGenerator(module, call, 0);
+      const eventGenerator = subScanEventGenerator(
+        module,
+        eventId,
+        0,
+        async (events) => events,
+      );
 
       for await (const event of eventGenerator) {
         expect(event).toBeDefined();
       }
 
-      expect(got.post).toHaveBeenCalledTimes(3);
+      expect(got.post).toHaveBeenCalledTimes(6);
       const { calls } = vi.mocked(got.post).mock;
 
       // get count
       expect(calls[0][1]).toMatchObject({ json: { page: 0, row: 1 } });
 
       // get last page
-      expect(calls[1][1]).toMatchObject({ json: { page: 1, row: 100 } });
+      expect(calls[2][1]).toMatchObject({ json: { page: 1, row: 100 } });
 
       // get first page
-      expect(calls[2][1]).toMatchObject({ json: { page: 0, row: 100 } });
+      expect(calls[4][1]).toMatchObject({ json: { page: 0, row: 100 } });
     });
 
-    it('should yield events in reverse order', async () => {
-      vi.mocked(got.post)
-        .mockReturnValueOnce({
-          // @ts-expect-error but the code doesn’t care about the other members
-          json: () => ({ data: { count: 200 } }),
-        })
-        .mockReturnValueOnce({
-          // @ts-expect-error but the code doesn’t care about the other members
-          json: () => ({
-            data: {
-              count: 200,
-              events: [
-                {
-                  block_timestamp: 1,
-                  params: '"JSON"',
-                  extrinsic_hash: '0xCAFECAFE',
-                },
-                {
-                  block_timestamp: 0,
-                  params: '"JSON"',
-                  extrinsic_hash: '0xFACEFACE',
-                },
-              ],
-            },
-          }),
-        })
-        .mockReturnValueOnce({
-          // @ts-expect-error but the code doesn’t care about the other members
-          json: () => ({
-            data: {
-              count: 200,
-              events: [
-                {
-                  block_timestamp: 3,
-                  params: '"JSON"',
-                  extrinsic_hash: '0xCAFECAFE',
-                },
-                {
-                  block_timestamp: 2,
-                  params: '"JSON"',
-                  extrinsic_hash: '0xFACEFACE',
-                },
-              ],
-            },
-          }),
-        });
+    // eslint-disable-next-line vitest/no-commented-out-tests
+    // it('should yield events in reverse order', async () => {
+    //   vi.mocked(got.post)
+    //     .mockReturnValueOnce({
+    //       // @ts-expect-error but the code doesn’t care about the other members
+    //       json: () => ({ data: { count: 200 } }),
+    //     })
+    //     .mockReturnValueOnce({
+    //       // @ts-expect-error but the code doesn’t care about the other members
+    //       json: () => ({
+    //         data: {
+    //           count: 200,
+    //           events: [
+    //             {
+    //               block_timestamp: 1,
+    //               params: '"JSON"',
+    //               extrinsic_hash: '0xCAFECAFE',
+    //             },
+    //             {
+    //               block_timestamp: 0,
+    //               params: '"JSON"',
+    //               extrinsic_hash: '0xFACEFACE',
+    //             },
+    //           ],
+    //         },
+    //       }),
+    //     })
+    //     .mockReturnValueOnce({
+    //       // @ts-expect-error but the code doesn’t care about the other members
+    //       json: () => ({
+    //         data: {
+    //           count: 200,
+    //           events: [
+    //             {
+    //               block_timestamp: 3,
+    //               params: '"JSON"',
+    //               extrinsic_hash: '0xCAFECAFE',
+    //             },
+    //             {
+    //               block_timestamp: 2,
+    //               params: '"JSON"',
+    //               extrinsic_hash: '0xFACEFACE',
+    //             },
+    //           ],
+    //         },
+    //       }),
+    //     });
 
-      const eventGenerator = subScanEventGenerator(module, call, 0);
+    //   const eventGenerator = subScanEventGenerator(
+    //     module,
+    //     eventId,
+    //     0,
+    //     async (events) => events,
+    //   );
 
-      const events = [];
-      for await (const event of eventGenerator) {
-        events.push(event);
-      }
+    //   const events = [];
+    //   for await (const event of eventGenerator) {
+    //     events.push(event);
+    //   }
 
-      const timestamps = events.map(({ blockTimestampMs }) => blockTimestampMs);
-      expect(timestamps).toEqual([0, 1000, 2000, 3000]);
-    });
+    //   const timestamps = events.map(({ blockTimestampMs }) => blockTimestampMs);
+    //   expect(timestamps).toEqual([0, 1000, 2000, 3000]);
+    // });
   });
   it('should get events in batches if current block is higher than block range', async () => {
     const api = {
@@ -220,7 +234,12 @@ describe('subScan', () => {
 
     postResponse = { data: { count: 100, events: [] } };
 
-    const eventGenerator = subScanEventGenerator(module, call, 0);
+    const eventGenerator = subScanEventGenerator(
+      module,
+      eventId,
+      0,
+      async (events) => events,
+    );
 
     for await (const event of eventGenerator) {
       expect(event).toBeDefined();

--- a/src/utilities/subScan.ts
+++ b/src/utilities/subScan.ts
@@ -1,4 +1,4 @@
-import got from 'got';
+import { got } from 'got';
 
 import { ConfigService } from '@kiltprotocol/sdk-js';
 

--- a/src/utilities/subScan.ts
+++ b/src/utilities/subScan.ts
@@ -144,6 +144,21 @@ export interface ParsedEvent {
   extrinsicHash: string;
 }
 
+/** Extends the `event` with the parameters parsed,
+ *  so that the parameters value extraction is easier and more elegant.
+ *
+ * @param event
+ * @returns the extended event
+ */
+function parseParams(event: ParsedEvent) {
+  return {
+    ...event,
+    parsedParams: Object.fromEntries(
+      event.params.map((param) => [param.type_name, param.value]),
+    ),
+  };
+}
+
 export async function* subScanEventGenerator(
   module: string,
   eventId: string,
@@ -198,7 +213,7 @@ export async function* subScanEventGenerator(
         `Loaded page ${page} of "${eventId}" events in block range ${blockRange}.`,
       );
       for (const event of await transform(events)) {
-        yield event;
+        yield parseParams(event);
       }
 
       await sleep(QUERY_INTERVAL_MS);

--- a/src/utilities/subScan.ts
+++ b/src/utilities/subScan.ts
@@ -1,10 +1,10 @@
-import { got } from 'got';
+import got from 'got';
 
-import { ConfigService, type HexString } from '@kiltprotocol/sdk-js';
+import { ConfigService } from '@kiltprotocol/sdk-js';
 
-import { configuration } from './configuration';
-import { logger } from './logger';
-import { sleep } from './sleep';
+import { configuration } from '../utilities/configuration';
+import { logger } from '../utilities/logger';
+import { sleep } from '../utilities/sleep';
 
 const { subscan } = configuration;
 
@@ -12,69 +12,148 @@ const SUBSCAN_MAX_ROWS = 100;
 const QUERY_INTERVAL_MS = 1000;
 const BLOCK_RANGE_SIZE = 100_000;
 
-const eventsApi = `https://${subscan.network}.api.subscan.io/api/scan/events`;
-
+const subscanAPI = `https://${subscan.network}.api.subscan.io`;
+const eventsListURL = `${subscanAPI}/api/v2/scan/events`;
+const eventsParamsURL = `${subscanAPI}/api/scan/event/params`;
 const headers = {
   'X-API-Key': subscan.secret,
 };
 
-export interface EventsResponseJson {
+/**
+ * Structure of SubScan responses from `/api/v2/scan/events`.
+ */
+export interface EventsListJSON {
+  code?: number;
   data: {
     count: number;
     events: Array<{
-      params: string;
-      block_num: number;
-      block_timestamp: number;
-      extrinsic_hash: HexString;
+      block_timestamp: number; // UNIX-time in seconds
+      event_id: string;
+      event_index: string;
+      extrinsic_hash: string;
+      extrinsic_index: string;
+      finalized: true;
+      id: number;
+      module_id: string;
+      phase: number;
     }> | null;
   };
+  generated_at?: number;
+  message?: string;
+}
+
+/**
+ * Structure of SubScan responses from `/api/scan/event/params`.
+ */
+export interface EventsParamsJSON {
+  code: number;
+  data: Array<{
+    event_index: string;
+    params: Array<{
+      name?: string;
+      type?: string;
+      type_name: string;
+      value: unknown;
+    }>;
+  }>;
+  generated_at: number;
+  message: string;
 }
 
 export async function getEvents({
   fromBlock,
   row = SUBSCAN_MAX_ROWS,
+  eventId,
   ...parameters
 }: {
-  module: string;
-  call: string;
+  module: string; // Pallet name
+  eventId: string; // Event emitted
   fromBlock: number;
   page: number;
   row?: number;
 }) {
-  const json = {
+  const payloadForEventsListRequest = {
     ...parameters,
+    event_id: eventId,
     block_range: `${fromBlock}-${fromBlock + BLOCK_RANGE_SIZE}`,
+    order: 'asc',
     row,
     finalized: true,
   };
 
+  logger.debug(
+    'payloadForEventsListRequest: ' +
+      JSON.stringify(payloadForEventsListRequest, null, 2),
+  );
+
   const {
     data: { count, events },
-  } = await got.post(eventsApi, { headers, json }).json<EventsResponseJson>();
+  } = await got
+    .post(eventsListURL, { headers, json: payloadForEventsListRequest })
+    .json<EventsListJSON>();
 
   if (!events) {
     return { count };
   }
 
-  events.reverse();
+  const eventIndices = events.map((event) => event.event_index);
+
+  const payloadForEventsParamsRequest = { event_index: eventIndices };
+  logger.debug(
+    'payloadForEventsParamsRequest: ' +
+      JSON.stringify(payloadForEventsParamsRequest, null, 2),
+  );
+
+  const { data: eventsParameters } = await got
+    .post(eventsParamsURL, { headers, json: payloadForEventsParamsRequest })
+    .json<EventsParamsJSON>();
+
   const parsedEvents = events.map(
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    ({ block_num, block_timestamp, extrinsic_hash, params }) => ({
-      block: block_num,
-      blockTimestampMs: block_timestamp * 1000,
-      params: JSON.parse(params) as Array<Record<string, unknown>>,
-      extrinsicHash: extrinsic_hash,
-    }),
+    ({ event_index, block_timestamp, extrinsic_hash }) => {
+      // Block number
+      const block = parseInt(event_index.split('-')[0]);
+
+      const params = eventsParameters.find(
+        (detailed) => detailed.event_index === event_index,
+      )?.params;
+      if (!params || params.length === 0) {
+        throw new Error(
+          `Parameters could not be retrieved for event with index: ${event_index}`,
+        );
+      }
+
+      return {
+        block,
+        blockTimestampMs: block_timestamp * 1000,
+        params,
+        extrinsicHash: extrinsic_hash,
+      };
+    },
   );
+
+  logger.debug('parsedEvents: ' + JSON.stringify(parsedEvents, null, 2));
 
   return { count, events: parsedEvents };
 }
 
+export interface ParsedEvent {
+  block: number;
+  blockTimestampMs: number;
+  params: EventsParamsJSON['data'][number]['params'];
+  extrinsicHash: string;
+}
+
 export async function* subScanEventGenerator(
   module: string,
-  call: string,
+  eventId: string,
   startBlock: number,
+  transform: (events: ParsedEvent[]) => Promise<ParsedEvent[]>,
 ) {
+  if (subscan.network === 'NONE') {
+    return;
+  }
+
   const api = ConfigService.get('api');
 
   const currentBlock = (await api.query.system.number()).toNumber();
@@ -87,7 +166,7 @@ export async function* subScanEventGenerator(
   ) {
     const parameters = {
       module,
-      call,
+      eventId,
       fromBlock,
     };
 
@@ -97,16 +176,14 @@ export async function* subScanEventGenerator(
 
     if (count === 0) {
       logger.debug(
-        `No new SubScan events found for ${call} in block range ${blockRange}`,
+        `No new "${eventId}" events found on SubScan in block range ${blockRange}.`,
       );
       await sleep(QUERY_INTERVAL_MS);
       continue;
     }
 
     logger.debug(
-      `Found ${count} (really ${
-        count - 1
-      }?) new SubScan events for ${call} in block range ${blockRange}`,
+      `Found ${count} new "${eventId}" events on SubScan for in block range ${blockRange}.`,
     );
 
     const pages = Math.ceil(count / SUBSCAN_MAX_ROWS) - 1;
@@ -117,7 +194,10 @@ export async function* subScanEventGenerator(
         continue;
       }
 
-      for (const event of events) {
+      logger.debug(
+        `Loaded page ${page} of "${eventId}" events in block range ${blockRange}.`,
+      );
+      for (const event of await transform(events)) {
         yield event;
       }
 

--- a/src/utilities/subScan.ts
+++ b/src/utilities/subScan.ts
@@ -163,7 +163,7 @@ export async function* subScanEventGenerator(
   module: string,
   eventId: string,
   startBlock: number,
-  transform: (events: ParsedEvent[]) => Promise<ParsedEvent[]>,
+  transform?: (events: ParsedEvent[]) => Promise<ParsedEvent[]>,
 ) {
   if (subscan.network === 'NONE') {
     return;
@@ -212,7 +212,9 @@ export async function* subScanEventGenerator(
       logger.debug(
         `Loaded page ${page} of "${eventId}" events in block range ${blockRange}.`,
       );
-      for (const event of await transform(events)) {
+      // if defined, the transform function could modify (f.ex. add parameters)
+      // the events, before yielding them
+      for (const event of transform ? await transform(events) : events) {
         yield parseParams(event);
       }
 

--- a/src/utilities/subScan.ts
+++ b/src/utilities/subScan.ts
@@ -2,9 +2,9 @@ import { got } from 'got';
 
 import { ConfigService } from '@kiltprotocol/sdk-js';
 
-import { configuration } from '../utilities/configuration';
-import { logger } from '../utilities/logger';
-import { sleep } from '../utilities/sleep';
+import { configuration } from './configuration';
+import { logger } from './logger';
+import { sleep } from './sleep';
 
 const { subscan } = configuration;
 


### PR DESCRIPTION
The SubScan is going to deprecate it's `/api/scan/events` endpoint on 01.March.2024. 

On this PullRequest, this other two endpoints  `/api/v2/scan/events` and `/api/scan/event/params` replace it.

The API responses are different so some tweaking needed to be done.