### PR TITLE
fix: deduplicate env rpc endpoint and other minor improvements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,12 @@
 PORT=3000
 URL=http://127.0.0.1:3000
 DATABASE_URI=postgres://postgres:postgres@localhost:5432/postgres
-BLOCKCHAIN_ENDPOINT=wss://kilt-rpc.dwellir.com
+# while using the "...kilt.io" endpoints, please add a trailing "/" so that polkadot.js displays the right colors.
+BLOCKCHAIN_ENDPOINT=wss://kilt.ibp.network
 DID=
 SECRET_PAYER_MNEMONIC=
 SECRET_AUTHENTICATION_MNEMONIC=
 SECRET_ASSERTION_METHOD_MNEMONIC=
 SECRET_KEY_AGREEMENT_MNEMONIC=
 GRAPHQL_ENDPOINT=https://indexer.kilt.io/
-# while using the "...kilt.io" endpoints, please add a trailing "/" so that polkadot.js displays the right colors.
-POLKADOT_RPC_ENDPOINT=kilt.ibp.network
+

--- a/src/components/CTypeDetails/CTypeDetails.astro
+++ b/src/components/CTypeDetails/CTypeDetails.astro
@@ -47,6 +47,11 @@ const version = schema === schemaV1 ? 'V1' : 'draft-01';
 const kiltCType = CType.fromProperties(title, properties, version);
 
 const { w3nOrigin, blockchainEndpoint } = configuration;
+
+const linkToW3N = new URL(`${w3nOrigin}/${web3Name ?? creator}`);
+const linkToBlock = new URL(
+  `https://polkadot.js.org/apps/?rpc=${blockchainEndpoint}#/explorer/query/${block}`,
+);
 ---
 
 <section class={containerStyles.bigContainer}>
@@ -55,10 +60,10 @@ const { w3nOrigin, blockchainEndpoint } = configuration;
   <fieldset>
     <legend>Creator</legend>
     {
-      web3Name ? (
-        <a href={`${w3nOrigin}/${web3Name}`}>w3n:{web3Name}</a>
-      ) : (
-        <a href={`${w3nOrigin}/${creator}`}>{creator}</a>
+      (
+        <a href={linkToW3N.toString()}>
+          {web3Name ? `w3n:${web3Name}` : creator}
+        </a>
       )
     }
   </fieldset>
@@ -98,9 +103,7 @@ const { w3nOrigin, blockchainEndpoint } = configuration;
   <fieldset>
     <legend>Registration Block</legend>
 
-    <a
-      href={`https://polkadot.js.org/apps/?rpc=${blockchainEndpoint}#/explorer/query/${block}`}
-    >
+    <a href={linkToBlock.toString()}>
       {block}
     </a>
   </fieldset>

--- a/src/components/CTypeDetails/CTypeDetails.astro
+++ b/src/components/CTypeDetails/CTypeDetails.astro
@@ -46,7 +46,7 @@ const schemaV1 = CType.fromProperties('', {}).$schema;
 const version = schema === schemaV1 ? 'V1' : 'draft-01';
 const kiltCType = CType.fromProperties(title, properties, version);
 
-const { w3nOrigin, indexer } = configuration;
+const { w3nOrigin, blockchainEndpoint } = configuration;
 ---
 
 <section class={containerStyles.bigContainer}>
@@ -99,7 +99,7 @@ const { w3nOrigin, indexer } = configuration;
     <legend>Registration Block</legend>
 
     <a
-      href={`https://polkadot.js.org/apps/?rpc=wss%3A%2F%2F${indexer.polkadotRPCEndpoint}#/explorer/query/${block}`}
+      href={`https://polkadot.js.org/apps/?rpc=${blockchainEndpoint}#/explorer/query/${block}`}
     >
       {block}
     </a>

--- a/src/components/CTypeDetails/CTypeDetails.astro
+++ b/src/components/CTypeDetails/CTypeDetails.astro
@@ -48,10 +48,12 @@ const kiltCType = CType.fromProperties(title, properties, version);
 
 const { w3nOrigin, blockchainEndpoint } = configuration;
 
-const linkToW3N = new URL(`${w3nOrigin}/${web3Name ?? creator}`);
-const linkToBlock = new URL(
-  `https://polkadot.js.org/apps/?rpc=${blockchainEndpoint}#/explorer/query/${block}`,
-);
+const linkToW3N = new URL(w3nOrigin);
+linkToW3N.pathname = web3Name ?? creator;
+
+const linkToBlock = new URL(`https://polkadot.js.org/apps/`);
+linkToBlock.searchParams.set('rpc', blockchainEndpoint);
+linkToBlock.hash = `/explorer/query/${block}`;
 ---
 
 <section class={containerStyles.bigContainer}>
@@ -59,13 +61,7 @@ const linkToBlock = new URL(
 
   <fieldset>
     <legend>Creator</legend>
-    {
-      (
-        <a href={linkToW3N.toString()}>
-          {web3Name ? `w3n:${web3Name}` : creator}
-        </a>
-      )
-    }
+    {(<a href={linkToW3N}>{web3Name ? `w3n:${web3Name}` : creator}</a>)}
   </fieldset>
 
   <fieldset>
@@ -103,7 +99,7 @@ const linkToBlock = new URL(
   <fieldset>
     <legend>Registration Block</legend>
 
-    <a href={linkToBlock.toString()}>
+    <a href={linkToBlock}>
       {block}
     </a>
   </fieldset>

--- a/src/components/CTypeDetails/CTypeDetails.astro
+++ b/src/components/CTypeDetails/CTypeDetails.astro
@@ -58,7 +58,7 @@ const { w3nOrigin, blockchainEndpoint } = configuration;
       web3Name ? (
         <a href={`${w3nOrigin}/${web3Name}`}>w3n:{web3Name}</a>
       ) : (
-        <p>{creator}</p>
+        <a href={`${w3nOrigin}/${creator}`}>{creator}</a>
       )
     }
   </fieldset>

--- a/src/components/CTypeDetails/__snapshots__/CTypeDetails.test.ts.snap
+++ b/src/components/CTypeDetails/__snapshots__/CTypeDetails.test.ts.snap
@@ -121,7 +121,7 @@ exports[`CTypeDetails > should handle kitchen sink CType 1`] = `
   </fieldset>
   <fieldset>
     <legend>Registration Block</legend>
-    <a href="https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fplaceholder#/explorer/query/456">456</a>
+    <a href="https://polkadot.js.org/apps/?rpc=ws://localhost:32769#/explorer/query/456">456</a>
   </fieldset>
   <fieldset>
     <legend>Technical Details</legend>
@@ -215,7 +215,7 @@ exports[`CTypeDetails > should handle nested CType 1`] = `
   </fieldset>
   <fieldset>
     <legend>Registration Block</legend>
-    <a href="https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fplaceholder#/explorer/query/456">456</a>
+    <a href="https://polkadot.js.org/apps/?rpc=ws://localhost:32769#/explorer/query/456">456</a>
   </fieldset>
   <fieldset>
     <legend>Technical Details</legend>
@@ -281,7 +281,7 @@ exports[`CTypeDetails > should handle nested CType property 1`] = `
   </fieldset>
   <fieldset>
     <legend>Registration Block</legend>
-    <a href="https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fplaceholder#/explorer/query/321">321</a>
+    <a href="https://polkadot.js.org/apps/?rpc=ws://localhost:32769#/explorer/query/321">321</a>
   </fieldset>
   <fieldset>
     <legend>Technical Details</legend>
@@ -345,7 +345,7 @@ exports[`CTypeDetails > should match snapshot 1`] = `
   </fieldset>
   <fieldset>
     <legend>Registration Block</legend>
-    <a href="https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fplaceholder#/explorer/query/123">123</a>
+    <a href="https://polkadot.js.org/apps/?rpc=ws://localhost:32769#/explorer/query/123">123</a>
   </fieldset>
   <fieldset>
     <legend>Tags</legend>

--- a/src/components/CTypeDetails/__snapshots__/CTypeDetails.test.ts.snap
+++ b/src/components/CTypeDetails/__snapshots__/CTypeDetails.test.ts.snap
@@ -121,7 +121,7 @@ exports[`CTypeDetails > should handle kitchen sink CType 1`] = `
   </fieldset>
   <fieldset>
     <legend>Registration Block</legend>
-    <a href="https://polkadot.js.org/apps/?rpc=ws://localhost:32769#/explorer/query/456">456</a>
+    <a href="https://polkadot.js.org/apps/?rpc=ws%3A%2F%2Flocalhost%3A32769#/explorer/query/456">456</a>
   </fieldset>
   <fieldset>
     <legend>Technical Details</legend>
@@ -215,7 +215,7 @@ exports[`CTypeDetails > should handle nested CType 1`] = `
   </fieldset>
   <fieldset>
     <legend>Registration Block</legend>
-    <a href="https://polkadot.js.org/apps/?rpc=ws://localhost:32769#/explorer/query/456">456</a>
+    <a href="https://polkadot.js.org/apps/?rpc=ws%3A%2F%2Flocalhost%3A32769#/explorer/query/456">456</a>
   </fieldset>
   <fieldset>
     <legend>Technical Details</legend>
@@ -281,7 +281,7 @@ exports[`CTypeDetails > should handle nested CType property 1`] = `
   </fieldset>
   <fieldset>
     <legend>Registration Block</legend>
-    <a href="https://polkadot.js.org/apps/?rpc=ws://localhost:32769#/explorer/query/321">321</a>
+    <a href="https://polkadot.js.org/apps/?rpc=ws%3A%2F%2Flocalhost%3A32769#/explorer/query/321">321</a>
   </fieldset>
   <fieldset>
     <legend>Technical Details</legend>
@@ -345,7 +345,7 @@ exports[`CTypeDetails > should match snapshot 1`] = `
   </fieldset>
   <fieldset>
     <legend>Registration Block</legend>
-    <a href="https://polkadot.js.org/apps/?rpc=ws://localhost:32769#/explorer/query/123">123</a>
+    <a href="https://polkadot.js.org/apps/?rpc=ws%3A%2F%2Flocalhost%3A32769#/explorer/query/123">123</a>
   </fieldset>
   <fieldset>
     <legend>Tags</legend>

--- a/src/components/CTypeDetails/__snapshots__/CTypeDetails.test.ts.snap
+++ b/src/components/CTypeDetails/__snapshots__/CTypeDetails.test.ts.snap
@@ -27,7 +27,7 @@ exports[`CTypeDetails > should handle kitchen sink CType 1`] = `
   <h1 class="title">Everything everywhere</h1>
   <fieldset>
     <legend>Creator</legend>
-    <p>did:kilt:4rrkiRTZgsgxjJDFkLsivqqKTqdUTuxKk3FX3mKFAeMxsR5E</p>
+    <a href="https://w3n.id/did:kilt:4rrkiRTZgsgxjJDFkLsivqqKTqdUTuxKk3FX3mKFAeMxsR5E">did:kilt:4rrkiRTZgsgxjJDFkLsivqqKTqdUTuxKk3FX3mKFAeMxsR5E</a>
   </fieldset>
   <fieldset>
     <legend>Number of attestations</legend>
@@ -179,7 +179,7 @@ exports[`CTypeDetails > should handle nested CType 1`] = `
   <h1 class="title">Example nested CType</h1>
   <fieldset>
     <legend>Creator</legend>
-    <p>did:kilt:4pehddkhEanexVTTzWAtrrfo2R7xPnePpuiJLC7shQU894aY</p>
+    <a href="https://w3n.id/did:kilt:4pehddkhEanexVTTzWAtrrfo2R7xPnePpuiJLC7shQU894aY">did:kilt:4pehddkhEanexVTTzWAtrrfo2R7xPnePpuiJLC7shQU894aY</a>
   </fieldset>
   <fieldset>
     <legend>Number of attestations</legend>
@@ -245,7 +245,7 @@ exports[`CTypeDetails > should handle nested CType property 1`] = `
   <h1 class="title">Example nested CType property</h1>
   <fieldset>
     <legend>Creator</legend>
-    <p>did:kilt:4pehddkhEanexVTTzWAtrrfo2R7xPnePpuiJLC7shQU894aY</p>
+    <a href="https://w3n.id/did:kilt:4pehddkhEanexVTTzWAtrrfo2R7xPnePpuiJLC7shQU894aY">did:kilt:4pehddkhEanexVTTzWAtrrfo2R7xPnePpuiJLC7shQU894aY</a>
   </fieldset>
   <fieldset>
     <legend>Number of attestations</legend>
@@ -311,7 +311,7 @@ exports[`CTypeDetails > should match snapshot 1`] = `
   <h1 class="title">Example CType</h1>
   <fieldset>
     <legend>Creator</legend>
-    <p>did:kilt:4pehddkhEanexVTTzWAtrrfo2R7xPnePpuiJLC7shQU894aY</p>
+    <a href="https://w3n.id/did:kilt:4pehddkhEanexVTTzWAtrrfo2R7xPnePpuiJLC7shQU894aY">did:kilt:4pehddkhEanexVTTzWAtrrfo2R7xPnePpuiJLC7shQU894aY</a>
   </fieldset>
   <fieldset>
     <legend>Number of attestations</legend>

--- a/src/utilities/configuration.ts
+++ b/src/utilities/configuration.ts
@@ -53,7 +53,7 @@ if (!payerMnemonic) {
 }
 
 function deductW3nOrigin(blockchainEndpoint: string) {
-  const endpoint = blockchainEndpoint.toLocaleLowerCase();
+  const endpoint = blockchainEndpoint.toLowerCase();
   if (endpoint.includes('peregrine-stg')) {
     return 'https://smoke.w3n.id';
   }

--- a/src/utilities/configuration.ts
+++ b/src/utilities/configuration.ts
@@ -52,11 +52,16 @@ if (!payerMnemonic) {
   throw new ConfigurationError('SECRET_PAYER_MNEMONIC is not provided');
 }
 
-const w3nOrigins: Record<string, string> = {
-  'wss://peregrine.kilt.io': 'https://test.w3n.id',
-  'wss://peregrine-stg.kilt.io/para': 'https://smoke.w3n.id',
-  'wss://kilt-rpc.dwellir.com': 'https://w3n.id',
-};
+function deductW3nOrigin(blockchainEndpoint: string) {
+  const endpoint = blockchainEndpoint.toLocaleLowerCase();
+  if (endpoint.includes('peregrine-stg')) {
+    return 'https://smoke.w3n.id';
+  }
+  if (endpoint.includes('peregrine')) {
+    return 'https://test.w3n.id';
+  }
+  return 'https://w3n.id';
+}
 
 export const configuration = {
   isProduction: import.meta.env.PROD,
@@ -71,6 +76,6 @@ export const configuration = {
   assertionMethodMnemonic,
   keyAgreementMnemonic,
   payerMnemonic,
-  w3nOrigin: w3nOrigins[blockchainEndpoint] || 'https://w3n.id',
+  w3nOrigin: deductW3nOrigin(blockchainEndpoint),
   indexer,
 };

--- a/src/utilities/configuration.ts
+++ b/src/utilities/configuration.ts
@@ -14,16 +14,11 @@ class ConfigurationError extends Error {
 }
 const indexer = {
   graphqlEndpoint: import.meta.env.GRAPHQL_ENDPOINT as string,
-  polkadotRPCEndpoint: import.meta.env.POLKADOT_RPC_ENDPOINT as string,
 };
 if (!indexer.graphqlEndpoint) {
   throw new ConfigurationError('No endpoint for the GraphQL server provided');
 }
-if (!indexer.polkadotRPCEndpoint) {
-  throw new ConfigurationError(
-    'No R.P.C. endpoint for the polkadot.js explorer provided',
-  );
-}
+
 const blockchainEndpoint = import.meta.env.BLOCKCHAIN_ENDPOINT as string;
 if (!blockchainEndpoint) {
   throw new ConfigurationError('No blockchain endpoint provided');

--- a/src/utilities/indexer/fragments.ts
+++ b/src/utilities/indexer/fragments.ts
@@ -1,6 +1,6 @@
 // GraphQL provides reusable units called fragments.
 // Fragments let you construct sets of fields, and then include them in queries where needed.
-// You can use the fragments by including them as fields prefixed by 3 points "...", like shown on 'wholeAttestation'.
+// You can use the fragments by including them as fields prefixed by 3 points "...".
 // See documentation here: https://graphql.org/learn/queries/#fragments
 // Try out yourself under https://indexer.kilt.io/ & https://dev-indexer.kilt.io/
 

--- a/src/utilities/indexer/queryCTypes.ts
+++ b/src/utilities/indexer/queryCTypes.ts
@@ -93,7 +93,7 @@ export async function queryCTypes() {
     } catch (error) {
       logger.error(
         error,
-        `Could not add cType ${cTypeId} to database. Probably bad formatted, see it's definition: ${definition}`,
+        `Could not add cType ${cTypeId} to database. Probably bad formatted, see its definition: ${definition}`,
       );
       continue;
     }

--- a/src/utilities/indexer/queryCTypes.ts
+++ b/src/utilities/indexer/queryCTypes.ts
@@ -77,17 +77,25 @@ export async function queryCTypes() {
     const { id: creator } = author;
     const { $schema, ...rest } = JSON.parse(definition) as Omit<ICType, '$id'>;
 
-    const newCType = await CTypeModel.upsert({
-      id: cTypeId,
-      schema: $schema,
-      createdAt: new Date(registrationBlock.timeStamp + 'Z'),
-      creator,
-      block: registrationBlock.id,
-      ...rest,
-      attestationsCreated,
-    });
-    logger.info(
-      `Added new CType to data base: ${JSON.stringify(newCType, null, 2)}`,
-    );
+    try {
+      const newCType = await CTypeModel.upsert({
+        id: cTypeId,
+        schema: $schema,
+        createdAt: new Date(registrationBlock.timeStamp + 'Z'),
+        creator,
+        block: registrationBlock.id,
+        ...rest,
+        attestationsCreated,
+      });
+      logger.info(
+        `Added new CType to data base: ${JSON.stringify(newCType, null, 2)}`,
+      );
+    } catch (error) {
+      logger.error(
+        error,
+        `Could not add cType ${cTypeId} to database. Probably bad formatted, see it's definition: ${definition}`,
+      );
+      continue;
+    }
   }
 }

--- a/src/utilities/indexer/queryFromIndexer.ts
+++ b/src/utilities/indexer/queryFromIndexer.ts
@@ -6,8 +6,8 @@ import { sleep } from '../sleep';
 
 const { indexer } = configuration;
 
-const QUERY_INTERVAL_MS = 1000;
-export const QUERY_SIZE = 50;
+const QUERY_INTERVAL_MS = 2000;
+export const QUERY_SIZE = 100;
 
 // /** Example Query. */
 // const queryBlocks = `

--- a/testing/globalSetup.ts
+++ b/testing/globalSetup.ts
@@ -15,7 +15,6 @@ import {
 const env = {
   MODE: 'test',
   GRAPHQL_ENDPOINT: 'placeholder',
-  POLKADOT_RPC_ENDPOINT: 'placeholder',
   BLOCKCHAIN_ENDPOINT: '',
   DATABASE_URI: '',
   DID: 'placeholder',


### PR DESCRIPTION
- Deduplicates environment constant for rpc endpoint => unifies `BLOCKCHAIN_ENDPOINT` and `POLKADOT_RPC_ENDPOINT`.
- Changes the `QUERY_SIZE` from **50** to **100** that is the maximum of the _indexer_.
- Handles case of bad cType written on chain (and on the indexer). 