### PR TITLE
feat: simplify sequelize usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,6 @@
 PORT=3000
 URL=http://127.0.0.1:3000
-## You need to export this variable manually to make it available for sequelize
-## via `export DATABASE_URI=...` on the command line interface
+# DATABASE_URI=<protocol://username:password@host:port/database>
 DATABASE_URI=postgres://postgres:postgres@localhost:5432/postgres
 # while using the "...kilt.io" endpoints, please add a trailing "/" so that polkadot.js displays the right colors.
 BLOCKCHAIN_ENDPOINT=wss://kilt.ibp.network

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+## Duplicate this file in the same directory and name it `.env`.
+## Assign custom values for your project inside `.env`.
+
 PORT=3000
 URL=http://127.0.0.1:3000
 # DATABASE_URI=<protocol://username:password@host:port/database>

--- a/.sequelizerc
+++ b/.sequelizerc
@@ -1,3 +1,5 @@
+require('dotenv').config();
+
 module.exports = {
   url: process.env.DATABASE_URI,
   'migrations-path': 'src/migrations',

--- a/README.md
+++ b/README.md
@@ -46,19 +46,6 @@ The database should start to populate from the configured indexer.
 This project consciously did not define a `config/config.json` for sequelize.
 Instead, it relies on the `url` property inside `.sequilizerc`.
 In turn, the `url` takes `process.env.DATABASE_URI` as a value.
-This means that `DATABASE_URI` needs to previously be set as an environment variable, sadly manually.
-
-To be able to run any `sequelize-cli` commands, first you need to execute:
-
-```
-export DATABASE_URI=<protocol://username:password@host:port/database>
-```
-
-If you are using the default values, as created via `pnpm start-db`, it narrows it down to this:
-
-```
-export DATABASE_URI=postgres://postgres:postgres@localhost:5432/postgres
-```
 
 **Before introducing any changes to the database structure you new to recreate the past.**
 **For this follow these steps:**
@@ -73,8 +60,6 @@ export DATABASE_URI=postgres://postgres:postgres@localhost:5432/postgres
    ```
    pnpm migrate
    ```
-
-   _Remember to manually set the `DATABASE_URI` first as described above._
 
 3. Start the project to populate the database, by running:
    ```

--- a/README.md
+++ b/README.md
@@ -50,23 +50,29 @@ In turn, the `url` takes `process.env.DATABASE_URI` as a value.
 **Before introducing any changes to the database structure you new to recreate the past.**
 **For this follow these steps:**
 
-1. Start the database, if not running yet.
+1. Make sure you have all dependencies installed, running:
+
+   ```
+   pnpm install
+   ```
+
+2. Start the database, if not running yet.
    Locally, you can run:
    ```
    pnpm start-db
    ```
-2. Run all past migrations, via:
+3. Run all past migrations, via:
 
    ```
    pnpm migrate
    ```
 
-3. Start the project to populate the database, by running:
+4. Start the project to populate the database, by running:
    ```
    pnpm dev
    ```
    _After a while, you can stop the project, but the postgres container should continue running._
-4. Add the seeds to the database:
+5. Add the seeds to the database, by running:
    ```
    pnpm seed
    ```

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@polkadot/extension-dapp": "^0.46.5",
     "@polkadot/util": "^12.6.2",
     "astro": "^3.6.5",
+    "dotenv": "^16.4.7",
     "got": "^12.6.1",
     "http-status-codes": "^2.3.0",
     "lodash-es": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       astro:
         specifier: ^3.6.5
         version: 3.6.5(@types/node@20.14.6)(typescript@5.4.5)
+      dotenv:
+        specifier: ^16.4.7
+        version: 16.4.7
       got:
         specifier: ^12.6.1
         version: 12.6.1
@@ -2080,6 +2083,10 @@ packages:
 
   domutils@3.1.0:
     resolution: {integrity: sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==}
+
+  dotenv@16.4.7:
+    resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
+    engines: {node: '>=12'}
 
   dottie@2.0.6:
     resolution: {integrity: sha512-iGCHkfUc5kFekGiqhe8B/mdaurD+lakO9txNnTvKtA6PISrw86LgqHvRzWYPyoE2Ph5aMIrCw9/uko6XHTKCwA==}
@@ -7466,6 +7473,8 @@ snapshots:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
+
+  dotenv@16.4.7: {}
 
   dottie@2.0.6: {}
 


### PR DESCRIPTION
Rely on `dotenv` to load the environment variable `DATABASE_URI` to make it available for the sequelize configuration. 
On this way, there is no need to export the variable value manually. 