### PR TITLE
chore: update kiltprotocol and polkadot dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   "dependencies": {
     "@astrojs/node": "^6.1.0",
     "@astrojs/react": "^3.6.0",
-    "@kiltprotocol/sdk-js": "^0.35.2",
-    "@polkadot/extension-dapp": "^0.46.5",
+    "@kiltprotocol/sdk-js": "^0.36.0-rc.1",
+    "@polkadot/extension-dapp": "^0.47.0",
     "@polkadot/util": "^12.6.2",
     "astro": "^3.6.5",
     "dotenv": "^16.4.7",
@@ -80,5 +80,9 @@
     "typescript": "^5.4.5",
     "vitest": "^0.34.6",
     "vitest-github-actions-reporter": "^0.11.1"
+  },
+  "resolutions": {
+    "@kiltprotocol/type-definitions": "1.11501.0-peregrine",
+    "@kiltprotocol/augment-api": "1.11501.0-peregrine"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@kiltprotocol/type-definitions': 1.11501.0-peregrine
+  '@kiltprotocol/augment-api': 1.11501.0-peregrine
+
 importers:
 
   .:
@@ -15,11 +19,11 @@ importers:
         specifier: ^3.6.0
         version: 3.6.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@4.4.9(@types/node@20.14.6))
       '@kiltprotocol/sdk-js':
-        specifier: ^0.35.2
-        version: 0.35.2
+        specifier: ^0.36.0-rc.1
+        version: 0.36.0-rc.1(@kiltprotocol/type-definitions@1.11501.0-peregrine(@polkadot/types@11.3.1))(typescript@5.4.5)
       '@polkadot/extension-dapp':
-        specifier: ^0.46.5
-        version: 0.46.5(@polkadot/api@10.9.1)(@polkadot/util-crypto@12.3.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2)
+        specifier: ^0.47.0
+        version: 0.47.6(@polkadot/api@11.3.1)(@polkadot/util-crypto@12.6.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2)
       '@polkadot/util':
         specifier: ^12.6.2
         version: 12.6.2
@@ -845,56 +849,71 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
-  '@kiltprotocol/asset-did@0.35.2':
-    resolution: {integrity: sha512-HbMkmwQPH8nV4tYYeiS2oZDf60lFX3t0gf3ieiVyy0Grr/eXo7v3lJ5id4rJFPgrKjiraMbATVCYn3Bx420Lqg==}
+  '@kiltprotocol/asset-did@0.36.0-rc.1':
+    resolution: {integrity: sha512-CSErUL0pNUjI0snHsGlkdarn2uW7FocVvnKklREdg2KcedXkcAiS8snjChrIZNEflKk5bsSKYjiDkK4R9D6XJw==}
     engines: {node: '>=16.0'}
 
-  '@kiltprotocol/augment-api@0.35.2':
-    resolution: {integrity: sha512-kmyKkj9MB/RWOtwAE9PXdaW+I19zwo7rpvH9kEGgUor874aWxUr8274vZlHKHdvnDNPgWfiDsStfHyPUlZRyEg==}
+  '@kiltprotocol/augment-api@1.11501.0-peregrine':
+    resolution: {integrity: sha512-/uuNcttyadQWvH5+g29e3DDFaGbjdwWBSnELAkZf8M9PcrgYnAV4JfwhzgyrpX9j429nxWrHvZyih9YzZ3j/YA==}
+    hasBin: true
+    peerDependencies:
+      '@kiltprotocol/type-definitions': 1.11501.0-peregrine
+      '@polkadot/api': ~12.2.0
+      '@polkadot/typegen': ~12.2.0
+      '@polkadot/types': ^12.2.0
+      typescript: '*'
+    peerDependenciesMeta:
+      '@kiltprotocol/type-definitions':
+        optional: true
+      '@polkadot/typegen':
+        optional: true
+      '@polkadot/types':
+        optional: true
+
+  '@kiltprotocol/chain-helpers@0.36.0-rc.1':
+    resolution: {integrity: sha512-cCiFtQNkRkq+BvHN/qsuMcxjHRhan5crOz0tfZlVlDeMwPGYIYlqJoC5OxB6neb0SSf2Ra24354NXhWDXeq2RQ==}
     engines: {node: '>=16.0'}
 
-  '@kiltprotocol/chain-helpers@0.35.2':
-    resolution: {integrity: sha512-pn76h7+TotlvyiR6zRzDkgMDjXejsc9D3s/uZHDAtcG26SCymf1UM8fgnAvz0qx6/NgCHA4vYL/T7sVkaAYh4A==}
+  '@kiltprotocol/config@0.36.0-rc.1':
+    resolution: {integrity: sha512-RH2jL/7GN/kZopun/dO4dMfan3sqTIRsPlaJF9r1UhdPrqkqPdoRCG2KbrQwDmh2u2htxXQLUX1aAFha+ZJ2Ug==}
     engines: {node: '>=16.0'}
 
-  '@kiltprotocol/config@0.35.2':
-    resolution: {integrity: sha512-8Vm3EhHqPE4pEgqqnznrhreAPx042RPI1tTd+PTBTcpZZIpQxv9V8vr/GqyijteXWbQ001bc77YcoFo1cRaDqw==}
+  '@kiltprotocol/core@0.36.0-rc.1':
+    resolution: {integrity: sha512-97qzE3UID9fvDU6Ez0qrGBYTvA1CAIxUkW2/DxSpS0X1RT7K1fdQQIUfmD7dokAWHDIUBI84T4g8saDeEcneMQ==}
     engines: {node: '>=16.0'}
 
-  '@kiltprotocol/core@0.35.2':
-    resolution: {integrity: sha512-U8jdHCAA5+J9gGU1Fa1YgO11WyxPgSGt2eceHgIzWcKD7geqfhZLFX8BN9qOrrThvZ4whM8uGX7D8rtlG9rK5w==}
+  '@kiltprotocol/did@0.36.0-rc.1':
+    resolution: {integrity: sha512-DXeTM/ecc9QyoPSM8YgvPV1aehcl0j/sHyOSvakvLyeMd4ytEwg4u1XvlIVyrhLYgt1TURxM77vVj3bdbx72ag==}
     engines: {node: '>=16.0'}
 
-  '@kiltprotocol/did@0.35.2':
-    resolution: {integrity: sha512-N+kKw1DMe25QkWsrWEzQHHd+YRCmnBGKpop68o6NYS7s62qr2CtyVdJcd6QaV92bzc43pWfEV5qT/A1DTo9b4w==}
+  '@kiltprotocol/messaging@0.36.0-rc.1':
+    resolution: {integrity: sha512-ZdJh8EWRIiUQ2rqbkamuu7/D64QyKwpKyRZ5k3/1G3GTIiX30zVCzBXrEkVCGBljOicp1ZJCUY9l7u5BGkNEwg==}
     engines: {node: '>=16.0'}
 
-  '@kiltprotocol/messaging@0.35.2':
-    resolution: {integrity: sha512-4AErRZgq8/3XQHBcLBroUZMzdCYsnYcl+WDsCXpkRa3Py9Z2pgMVN/FtLDBFZLOzJGNBeUzE5HDcSai76PEkJw==}
+  '@kiltprotocol/sdk-js@0.36.0-rc.1':
+    resolution: {integrity: sha512-+jN+u+jDFN+p4tm3+M9pJVPW3OizLxeJzZwx3MQ2JH2qoSn3nI2eYuRw5Fc6rCfUCfTry2Jj1VHfYGNPU0Vz7w==}
     engines: {node: '>=16.0'}
 
-  '@kiltprotocol/sdk-js@0.35.2':
-    resolution: {integrity: sha512-IoIsORa/fMSDVSoTdYs4rPzc0YW6rwuN5wDfSt88RYD5WvOimawfjmYZKa0knwDPAvSTraBM/9GDsEboHg3Cqg==}
+  '@kiltprotocol/type-definitions@1.11501.0-peregrine':
+    resolution: {integrity: sha512-ZjO2lnlppdECH5Ix5FDrQvxMlqvr9wPtYfiNQ9sb7pn6dslSY6xlBwKMl0BlokdyIE4HGVLI0AiDz6av/MloAA==}
+    peerDependencies:
+      '@polkadot/types': ^12.2.0
+
+  '@kiltprotocol/types@0.36.0-rc.1':
+    resolution: {integrity: sha512-Uag0Tik8RZuiuo9IcTGWD0pLgAKhnHGHV3ll2F6m3m8mFscanWsu8v+5W7oQueXz+kbQfUZJiEqDWdwetTaaJw==}
     engines: {node: '>=16.0'}
 
-  '@kiltprotocol/type-definitions@0.35.2':
-    resolution: {integrity: sha512-S/sxtF6O6gLQWwPc2nS4tObWxevrZi9cnNl64butSQFoS1yhNrqwiI88XnlI44TnE1yBfTuqUVjfTroq2xqURw==}
+  '@kiltprotocol/utils@0.36.0-rc.1':
+    resolution: {integrity: sha512-kmLbFH8w+ixksibfV/rwqbTPrTjl5qfafjqBAu/QWxxztXyk0ntRus2AoiJjv7nucniotqKkGmtnDYI3KfINRQ==}
     engines: {node: '>=16.0'}
 
-  '@kiltprotocol/types@0.35.2':
-    resolution: {integrity: sha512-Q/xnzJvuuHKusz0uv45tfNr1HTGKDtXbCm3iMsH+HnFzfy4d/B2ZAmZVnmQQZqLPyo25wMCl9vaVMOzsmUFJ4g==}
-    engines: {node: '>=16.0'}
+  '@noble/curves@1.8.1':
+    resolution: {integrity: sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==}
+    engines: {node: ^14.21.3 || >=16}
 
-  '@kiltprotocol/utils@0.35.2':
-    resolution: {integrity: sha512-Vm3Pv8qRrCI0f4PTb6LqXdveezdTOpOctxoZJLSWr6ljoP30qfsrKiicE8ZbG6OlFGSuOkgPEFcmn4MGBH9aOw==}
-    engines: {node: '>=16.0'}
-
-  '@noble/curves@1.1.0':
-    resolution: {integrity: sha512-091oBExgENk/kGj3AZmtBDMpxQPDtxQABR2B9lb1JbVTs6ytdzZNwvhxQ4MWasRNEzlbEH8jCWFCwhF/Obj5AA==}
-
-  '@noble/hashes@1.3.1':
-    resolution: {integrity: sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==}
-    engines: {node: '>= 16'}
+  '@noble/hashes@1.7.1':
+    resolution: {integrity: sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==}
+    engines: {node: ^14.21.3 || >=16}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -912,186 +931,189 @@ packages:
     resolution: {integrity: sha512-POgTXhjrTfbTV63DiFXav4lBHiICLKKwDeaKn9Nphwj7WH6m0hMMCaJkMyRWjgtPFyRKRVoMXXjczsTQRDEhYw==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@polkadot/api-augment@10.9.1':
-    resolution: {integrity: sha512-kRZZvCFVcN4hAH4dJ+Qzfdy27/4EEq3oLDf3ihj0LTVrAezSWcKPGE3EVFy+Mn6Lo4SUc7RVyoKvIUhSk2l4Dg==}
-    engines: {node: '>=16'}
+  '@polkadot-api/json-rpc-provider-proxy@0.0.1':
+    resolution: {integrity: sha512-gmVDUP8LpCH0BXewbzqXF2sdHddq1H1q+XrAW2of+KZj4woQkIGBRGTJHeBEVHe30EB+UejR1N2dT4PO/RvDdg==}
 
-  '@polkadot/api-base@10.9.1':
-    resolution: {integrity: sha512-Q3m2KzlceMK2kX8bhnUZWk3RT6emmijeeFZZQgCePpEcrSeNjnqG4qjuTPgkveaOkUT8MAoDc5Avuzcc2jlW9g==}
-    engines: {node: '>=16'}
+  '@polkadot-api/json-rpc-provider@0.0.1':
+    resolution: {integrity: sha512-/SMC/l7foRjpykLTUTacIH05H3mr9ip8b5xxfwXlVezXrNVLp3Cv0GX6uItkKd+ZjzVPf3PFrDF2B2/HLSNESA==}
 
-  '@polkadot/api-derive@10.9.1':
-    resolution: {integrity: sha512-mRud1UZCFIc4Z63qAoGSIHh/foyUYADfy1RQYCmPpeFKfIdCIrHpd7xFdJXTOMYOS0BwlM6u4qli/ZT4XigezQ==}
-    engines: {node: '>=16'}
+  '@polkadot-api/metadata-builders@0.0.1':
+    resolution: {integrity: sha512-GCI78BHDzXAF/L2pZD6Aod/yl82adqQ7ftNmKg51ixRL02JpWUA+SpUKTJE5MY1p8kiJJIo09P2um24SiJHxNA==}
 
-  '@polkadot/api@10.9.1':
-    resolution: {integrity: sha512-ND/2UqZBWvtt4PfV03OStTKg0mxmPk4UpMAgJKutdgsz/wP9CYJ1KbjwFgPNekL9JnzbKQsWyQNPVrcw7kQk8A==}
-    engines: {node: '>=16'}
+  '@polkadot-api/observable-client@0.1.0':
+    resolution: {integrity: sha512-GBCGDRztKorTLna/unjl/9SWZcRmvV58o9jwU2Y038VuPXZcr01jcw/1O3x+yeAuwyGzbucI/mLTDa1QoEml3A==}
+    peerDependencies:
+      rxjs: '>=7.8.0'
 
-  '@polkadot/extension-dapp@0.46.5':
-    resolution: {integrity: sha512-9Efm3oorx6orq1eue+tTk5rxuGFFCUdRxiZbdQMKiVl3lZnwBn0M61ceE3xXcf/oIwAm8RhUpQdwcbZfupJRgw==}
-    engines: {node: '>=16'}
+  '@polkadot-api/substrate-bindings@0.0.1':
+    resolution: {integrity: sha512-bAe7a5bOPnuFVmpv7y4BBMRpNTnMmE0jtTqRUw/+D8ZlEHNVEJQGr4wu3QQCl7k1GnSV1wfv3mzIbYjErEBocg==}
+
+  '@polkadot-api/substrate-client@0.0.1':
+    resolution: {integrity: sha512-9Bg9SGc3AwE+wXONQoW8GC00N3v6lCZLW74HQzqB6ROdcm5VAHM4CB/xRzWSUF9CXL78ugiwtHx3wBcpx4H4Wg==}
+
+  '@polkadot-api/utils@0.0.1':
+    resolution: {integrity: sha512-3j+pRmlF9SgiYDabSdZsBSsN5XHbpXOAce1lWj56IEEaFZVjsiCaxDOA7C9nCcgfVXuvnbxqqEGQvnY+QfBAUw==}
+
+  '@polkadot/api-augment@11.3.1':
+    resolution: {integrity: sha512-Yj+6rb6h0WwY3yJ+UGhjGW+tyMRFUMsKQuGw+eFsXdjiNU9UoXsAqA2dG7Q1F+oeX/g+y2gLGBezNoCwbl6HfA==}
+    engines: {node: '>=18'}
+
+  '@polkadot/api-base@11.3.1':
+    resolution: {integrity: sha512-b8UkNL00NN7+3QaLCwL5cKg+7YchHoKCAhwKusWHNBZkkO6Oo2BWilu0dZkPJOyqV9P389Kbd9+oH+SKs9u2VQ==}
+    engines: {node: '>=18'}
+
+  '@polkadot/api-derive@11.3.1':
+    resolution: {integrity: sha512-9dopzrh4cRuft1nANmBvMY/hEhFDu0VICMTOGxQLOl8NMfcOFPTLAN0JhSBUoicGZhV+c4vpv01NBx/7/IL1HA==}
+    engines: {node: '>=18'}
+
+  '@polkadot/api@11.3.1':
+    resolution: {integrity: sha512-q4kFIIHTLvKxM24b0Eo8hJevsPMme+aITJGrDML9BgdZYTRN14+cu5nXiCsQvaEamdyYj+uCXWe2OV9X7pPxsA==}
+    engines: {node: '>=18'}
+
+  '@polkadot/extension-dapp@0.47.6':
+    resolution: {integrity: sha512-GpV0MQGL5c4y5lVcQXP+tf6Nnyqau/9ZHQnQdsWosnrjR0n9iak8UgWl1hQEGqBp/nYi9TdvdA4uFvcIjv1Jng==}
+    engines: {node: '>=18'}
     peerDependencies:
       '@polkadot/api': '*'
       '@polkadot/util': '*'
       '@polkadot/util-crypto': '*'
 
-  '@polkadot/extension-inject@0.46.5':
-    resolution: {integrity: sha512-QcpkCMuv7iFbWjufkw14JRozpEYFyjP0H8KOJ8IsHGfPd2DPiismQ0NXr+AS7f6U+0I+Rhv9E4dnXxtJPROVMQ==}
-    engines: {node: '>=16'}
+  '@polkadot/extension-inject@0.47.6':
+    resolution: {integrity: sha512-rDTHyjGBgNochLc5Us+H2YJXUb2HW4hJJ23+6B7Mv373mfBYtM1T1HDkIWzV/xNJmiboAQy4O41N71CmZq4j7g==}
+    engines: {node: '>=18'}
     peerDependencies:
       '@polkadot/api': '*'
       '@polkadot/util': '*'
 
-  '@polkadot/keyring@12.3.2':
-    resolution: {integrity: sha512-NTdtDeI0DP9l/45hXynNABeP5VB8piw5YR+CbUxK2e36xpJWVXwbcOepzslg5ghE9rs8UKJb30Z/HqTU4sBY0Q==}
-    engines: {node: '>=16'}
+  '@polkadot/keyring@12.6.2':
+    resolution: {integrity: sha512-O3Q7GVmRYm8q7HuB3S0+Yf/q/EB2egKRRU3fv9b3B7V+A52tKzA+vIwEmNVaD1g5FKW9oB97rmpggs0zaKFqHw==}
+    engines: {node: '>=18'}
     peerDependencies:
-      '@polkadot/util': 12.3.2
-      '@polkadot/util-crypto': 12.3.2
+      '@polkadot/util': 12.6.2
+      '@polkadot/util-crypto': 12.6.2
 
-  '@polkadot/networks@12.3.2':
-    resolution: {integrity: sha512-uCkyybKoeEm1daKr0uT/9oNDHDDzCy2/ZdVl346hQqfdR1Ct3BaxMjxqvdmb5N8aCw0cBWSfgsxAYtw8ESmllQ==}
-    engines: {node: '>=16'}
+  '@polkadot/networks@12.6.2':
+    resolution: {integrity: sha512-1oWtZm1IvPWqvMrldVH6NI2gBoCndl5GEwx7lAuQWGr7eNL+6Bdc5K3Z9T0MzFvDGoi2/CBqjX9dRKo39pDC/w==}
+    engines: {node: '>=18'}
 
-  '@polkadot/rpc-augment@10.9.1':
-    resolution: {integrity: sha512-MaLHkNlyqN20ZRYr6uNd1BZr1OsrnX9qLAmsl0mcrri1vPGRH6VHjfFH1RBLkikpWD82v17g0l2hLwdV1ZHMcw==}
-    engines: {node: '>=16'}
+  '@polkadot/rpc-augment@11.3.1':
+    resolution: {integrity: sha512-2PaDcKNju4QYQpxwVkWbRU3M0t340nMX9cMo+8awgvgL1LliV/fUDZueMKLuSS910JJMTPQ7y2pK4eQgMt08gQ==}
+    engines: {node: '>=18'}
 
-  '@polkadot/rpc-core@10.9.1':
-    resolution: {integrity: sha512-ZtA8B8SfXSAwVkBlCcKRHw0eSM7ec/sbiNOM5GasXPeRujUgT7lOwSH2GbUZSqe9RfRDMp6DvO9c2JoGc3LLWw==}
-    engines: {node: '>=16'}
+  '@polkadot/rpc-core@11.3.1':
+    resolution: {integrity: sha512-KKNepsDd/mpmXcA6v/h14eFFPEzLGd7nrvx2UUXUxoZ0Fq2MH1hplP3s93k1oduNY/vOXJR2K9S4dKManA6GVQ==}
+    engines: {node: '>=18'}
 
-  '@polkadot/rpc-provider@10.9.1':
-    resolution: {integrity: sha512-4QzT2QzD+320+eT6b79sGAA85Tt3Bb8fQvse4r5Mom2iiBd2SO81vOhxSAOaIe4GUsw25VzFJmsbe7+OObItdg==}
-    engines: {node: '>=16'}
+  '@polkadot/rpc-provider@11.3.1':
+    resolution: {integrity: sha512-pqERChoHo45hd3WAgW8UuzarRF+G/o/eXEbl0PXLubiayw4X4qCmIzmtntUcKYgxGNcYGZaG87ZU8OjN97m6UA==}
+    engines: {node: '>=18'}
 
-  '@polkadot/types-augment@10.9.1':
-    resolution: {integrity: sha512-OY9/jTMFRFqYdkUnfcGwqMLC64A0Q25bjvCuVQCVjsPFKE3wl0Kt5rNT01eV2UmLXrR6fY0xWbR2w80bLA7CIQ==}
-    engines: {node: '>=16'}
+  '@polkadot/types-augment@11.3.1':
+    resolution: {integrity: sha512-eR3HVpvUmB3v7q2jTWVmVfAVfb1/kuNn7ij94Zqadg/fuUq0pKqIOKwkUj3OxRM3A/5BnW3MbgparjKD3r+fyw==}
+    engines: {node: '>=18'}
 
-  '@polkadot/types-codec@10.9.1':
-    resolution: {integrity: sha512-mJ5OegKGraY1FLvEa8FopRCr3pQrhDkcn5RNOjmgJQozENVeRaxhk0NwxYz7IojFvSDnKnc6lNQfKaaSe5pLHg==}
-    engines: {node: '>=16'}
+  '@polkadot/types-codec@11.3.1':
+    resolution: {integrity: sha512-i7IiiuuL+Z/jFoKTA9xeh4wGQnhnNNjMT0+1ohvlOvnFsoKZKFQQOaDPPntGJVL1JDCV+KjkN2uQKZSeW8tguQ==}
+    engines: {node: '>=18'}
 
-  '@polkadot/types-create@10.9.1':
-    resolution: {integrity: sha512-OVz50MGTTuiuVnRP/zAx4CTuLioc0hsiwNwqN2lNhmIJGtnQ4Vy/7mQRsIWehiYz6g0Vzzm5B3qWkTXO1NSN5w==}
-    engines: {node: '>=16'}
+  '@polkadot/types-create@11.3.1':
+    resolution: {integrity: sha512-pBXtpz5FehcRJ6j5MzFUIUN8ZWM7z6HbqK1GxBmYbJVRElcGcOg7a/rL2pQVphU0Rx1E8bSO4thzGf4wUxSX7w==}
+    engines: {node: '>=18'}
 
-  '@polkadot/types-known@10.9.1':
-    resolution: {integrity: sha512-zCMVWc4pJtkbMFPu72bD4IhvV/gkHXPX3C5uu92WdmCfnn0vEIEsMKWlVXVVvQQZKAqvs/awpqIfrUtEViOGEA==}
-    engines: {node: '>=16'}
+  '@polkadot/types-known@11.3.1':
+    resolution: {integrity: sha512-3BIof7u6tn9bk3ZCIxA07iNoQ3uj4+vn3DTOjCKECozkRlt6V+kWRvqh16Hc0SHMg/QjcMb2fIu/WZhka1McUQ==}
+    engines: {node: '>=18'}
 
-  '@polkadot/types-support@10.9.1':
-    resolution: {integrity: sha512-XsieuLDsszvMZQlleacQBfx07i/JkwQV/UxH9q8Hz7Okmaz9pEVEW1h3ka2/cPuC7a4l32JhaORBUYshBZNdJg==}
-    engines: {node: '>=16'}
+  '@polkadot/types-support@11.3.1':
+    resolution: {integrity: sha512-jTFz1GKyF7nI29yIOq4v0NiWTOf5yX4HahJNeFD8TcxoLhF+6tH/XXqrUXJEfbaTlSrRWiW1LZYlb+snctqKHA==}
+    engines: {node: '>=18'}
 
-  '@polkadot/types@10.9.1':
-    resolution: {integrity: sha512-AG33i2ZGGfq7u+5rkAdGrXAQHHl844/Yv+junH5ZzX69xiCoWO1bH/yzDUNBdpki2GlACWvF9nLYh3F2tVF93w==}
-    engines: {node: '>=16'}
+  '@polkadot/types@11.3.1':
+    resolution: {integrity: sha512-5c7uRFXQTT11Awi6T0yFIdAfD6xGDAOz06Kp7M5S9OGNZY28wSPk5x6BYfNphWPaIBmHHewYJB5qmnrdYQAWKQ==}
+    engines: {node: '>=18'}
 
-  '@polkadot/util-crypto@12.3.2':
-    resolution: {integrity: sha512-pTpx+YxolY0BDT4RcGmgeKbHHD/dI6Ll9xRsqmVdIjpcVVY20uDNTyXs81ZNtfKgyod1y9JQkfNv2Dz9iEpTkQ==}
-    engines: {node: '>=16'}
+  '@polkadot/util-crypto@12.6.2':
+    resolution: {integrity: sha512-FEWI/dJ7wDMNN1WOzZAjQoIcCP/3vz3wvAp5QQm+lOrzOLj0iDmaIGIcBkz8HVm3ErfSe/uKP0KS4jgV/ib+Mg==}
+    engines: {node: '>=18'}
     peerDependencies:
-      '@polkadot/util': 12.3.2
-
-  '@polkadot/util@12.3.2':
-    resolution: {integrity: sha512-y/JShcGyOamCUiSIg++XZuLHt1ktSKBaSH2K5Nw5NXlgP0+7am+GZzqPB8fQ4qhYLruEOv+YRiz0GC1Zr9S+wg==}
-    engines: {node: '>=16'}
+      '@polkadot/util': 12.6.2
 
   '@polkadot/util@12.6.2':
     resolution: {integrity: sha512-l8TubR7CLEY47240uki0TQzFvtnxFIO7uI/0GoWzpYD/O62EIAMRsuY01N4DuwgKq2ZWD59WhzsLYmA5K6ksdw==}
     engines: {node: '>=18'}
 
-  '@polkadot/wasm-bridge@7.2.1':
-    resolution: {integrity: sha512-uV/LHREDBGBbHrrv7HTki+Klw0PYZzFomagFWII4lp6Toj/VCvRh5WMzooVC+g/XsBGosAwrvBhoModabyHx+A==}
-    engines: {node: '>=16'}
+  '@polkadot/wasm-bridge@7.4.1':
+    resolution: {integrity: sha512-tdkJaV453tezBxhF39r4oeG0A39sPKGDJmN81LYLf+Fihb7astzwju+u75BRmDrHZjZIv00un3razJEWCxze6g==}
+    engines: {node: '>=18'}
     peerDependencies:
       '@polkadot/util': '*'
       '@polkadot/x-randomvalues': '*'
 
-  '@polkadot/wasm-crypto-asmjs@7.2.1':
-    resolution: {integrity: sha512-z/d21bmxyVfkzGsKef/FWswKX02x5lK97f4NPBZ9XBeiFkmzlXhdSnu58/+b1sKsRAGdW/Rn/rTNRDhW0GqCAg==}
-    engines: {node: '>=16'}
+  '@polkadot/wasm-crypto-asmjs@7.4.1':
+    resolution: {integrity: sha512-pwU8QXhUW7IberyHJIQr37IhbB6DPkCG5FhozCiNTq4vFBsFPjm9q8aZh7oX1QHQaiAZa2m2/VjIVE+FHGbvHQ==}
+    engines: {node: '>=18'}
     peerDependencies:
       '@polkadot/util': '*'
 
-  '@polkadot/wasm-crypto-init@7.2.1':
-    resolution: {integrity: sha512-GcEXtwN9LcSf32V9zSaYjHImFw16hCyo2Xzg4GLLDPPeaAAfbFr2oQMgwyDbvBrBjLKHVHjsPZyGhXae831amw==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      '@polkadot/util': '*'
-      '@polkadot/x-randomvalues': '*'
-
-  '@polkadot/wasm-crypto-wasm@7.2.1':
-    resolution: {integrity: sha512-DqyXE4rSD0CVlLIw88B58+HHNyrvm+JAnYyuEDYZwCvzUWOCNos/DDg9wi/K39VAIsCCKDmwKqkkfIofuOj/lA==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      '@polkadot/util': '*'
-
-  '@polkadot/wasm-crypto@7.2.1':
-    resolution: {integrity: sha512-SA2+33S9TAwGhniKgztVN6pxUKpGfN4Tre/eUZGUfpgRkT92wIUT2GpGWQE+fCCqGQgADrNiBcwt6XwdPqMQ4Q==}
-    engines: {node: '>=16'}
+  '@polkadot/wasm-crypto-init@7.4.1':
+    resolution: {integrity: sha512-AVka33+f7MvXEEIGq5U0dhaA2SaXMXnxVCQyhJTaCnJ5bRDj0Xlm3ijwDEQUiaDql7EikbkkRtmlvs95eSUWYQ==}
+    engines: {node: '>=18'}
     peerDependencies:
       '@polkadot/util': '*'
       '@polkadot/x-randomvalues': '*'
 
-  '@polkadot/wasm-util@7.2.1':
-    resolution: {integrity: sha512-FBSn/3aYJzhN0sYAYhHB8y9JL8mVgxLy4M1kUXYbyo+8GLRQEN5rns8Vcb8TAlIzBWgVTOOptYBvxo0oj0h7Og==}
-    engines: {node: '>=16'}
+  '@polkadot/wasm-crypto-wasm@7.4.1':
+    resolution: {integrity: sha512-PE1OAoupFR0ZOV2O8tr7D1FEUAwaggzxtfs3Aa5gr+yxlSOaWUKeqsOYe1KdrcjmZVV3iINEAXxgrbzCmiuONg==}
+    engines: {node: '>=18'}
     peerDependencies:
       '@polkadot/util': '*'
 
-  '@polkadot/x-bigint@12.3.2':
-    resolution: {integrity: sha512-JLqLgfGXe/x+hZJETd5ZqfpVsbwyMsH5Nn1Q20ineMMjXN/ig+kVR8Mc15LXBMuw4g7LldFW6UUrotWnuMI8Yw==}
-    engines: {node: '>=16'}
+  '@polkadot/wasm-crypto@7.4.1':
+    resolution: {integrity: sha512-kHN/kF7hYxm1y0WeFLWeWir6oTzvcFmR4N8fJJokR+ajYbdmrafPN+6iLgQVbhZnDdxyv9jWDuRRsDnBx8tPMQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@polkadot/util': '*'
+      '@polkadot/x-randomvalues': '*'
+
+  '@polkadot/wasm-util@7.4.1':
+    resolution: {integrity: sha512-RAcxNFf3zzpkr+LX/ItAsvj+QyM56TomJ0xjUMo4wKkHjwsxkz4dWJtx5knIgQz/OthqSDMR59VNEycQeNuXzA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@polkadot/util': '*'
 
   '@polkadot/x-bigint@12.6.2':
     resolution: {integrity: sha512-HSIk60uFPX4GOFZSnIF7VYJz7WZA7tpFJsne7SzxOooRwMTWEtw3fUpFy5cYYOeLh17/kHH1Y7SVcuxzVLc74Q==}
     engines: {node: '>=18'}
 
-  '@polkadot/x-fetch@12.3.2':
-    resolution: {integrity: sha512-3IEuZ5S+RI/t33NsdPLIIa5COfDCfpUW2sbaByEczn75aD1jLqJZSEDwiBniJ2osyNd4uUxBf6e5jw7LAZeZJg==}
-    engines: {node: '>=16'}
-
-  '@polkadot/x-global@12.3.2':
-    resolution: {integrity: sha512-yVZq6oIegjlyh5rUZiTklgu+fL+W/DG1ypEa02683tUCB3avV5cA3PAHKptMSlb6FpweHu37lKKrqfAWrraDxg==}
-    engines: {node: '>=16'}
+  '@polkadot/x-fetch@12.6.2':
+    resolution: {integrity: sha512-8wM/Z9JJPWN1pzSpU7XxTI1ldj/AfC8hKioBlUahZ8gUiJaOF7K9XEFCrCDLis/A1BoOu7Ne6WMx/vsJJIbDWw==}
+    engines: {node: '>=18'}
 
   '@polkadot/x-global@12.6.2':
     resolution: {integrity: sha512-a8d6m+PW98jmsYDtAWp88qS4dl8DyqUBsd0S+WgyfSMtpEXu6v9nXDgPZgwF5xdDvXhm+P0ZfVkVTnIGrScb5g==}
     engines: {node: '>=18'}
 
-  '@polkadot/x-randomvalues@12.3.2':
-    resolution: {integrity: sha512-ywjIs8CWpvOGmq+3cGCNPOHxAjPHdBUiXyDccftx5BRVdmtbt36gK/V84bKr6Xs73FGu0jprUAOSRRsLZX/3dg==}
-    engines: {node: '>=16'}
+  '@polkadot/x-randomvalues@12.6.2':
+    resolution: {integrity: sha512-Vr8uG7rH2IcNJwtyf5ebdODMcr0XjoCpUbI91Zv6AlKVYOGKZlKLYJHIwpTaKKB+7KPWyQrk4Mlym/rS7v9feg==}
+    engines: {node: '>=18'}
     peerDependencies:
-      '@polkadot/util': 12.3.2
+      '@polkadot/util': 12.6.2
       '@polkadot/wasm-util': '*'
-
-  '@polkadot/x-textdecoder@12.3.2':
-    resolution: {integrity: sha512-lY5bfA5xArJRWEJlYOlQQMJeTjWD8s0yMhchirVgf5xj8Id9vPGeUoneH+VFDEwgXxrqBvDFJ4smN4T/r6a/fg==}
-    engines: {node: '>=16'}
 
   '@polkadot/x-textdecoder@12.6.2':
     resolution: {integrity: sha512-M1Bir7tYvNappfpFWXOJcnxUhBUFWkUFIdJSyH0zs5LmFtFdbKAeiDXxSp2Swp5ddOZdZgPac294/o2TnQKN1w==}
     engines: {node: '>=18'}
 
-  '@polkadot/x-textencoder@12.3.2':
-    resolution: {integrity: sha512-iP3qEBiHzBckQ9zeY7ZHRWuu7mCEg5SMpOugs6UODRk8sx6KHzGQYlghBbWLit0uppPDVE0ifEwZ2n73djJHWQ==}
-    engines: {node: '>=16'}
-
   '@polkadot/x-textencoder@12.6.2':
     resolution: {integrity: sha512-4N+3UVCpI489tUJ6cv3uf0PjOHvgGp9Dl+SZRLgFGt9mvxnvpW/7+XBADRMtlG4xi5gaRK7bgl5bmY6OMDsNdw==}
     engines: {node: '>=18'}
 
-  '@polkadot/x-ws@12.3.2':
-    resolution: {integrity: sha512-yM9Z64pLNlHpJE43+Xtr+iUXmYpFFY5u5hrke2PJt13O48H8f9Vb9cRaIh94appLyICoS0aekGhDkGH+MCspBA==}
-    engines: {node: '>=16'}
+  '@polkadot/x-ws@12.6.2':
+    resolution: {integrity: sha512-cGZWo7K5eRRQCRl2LrcyCYsrc3lRbTlixZh3AzgU8uX4wASVGRlNWi/Hf4TtHNe1ExCDmxabJzdIsABIfrr7xw==}
+    engines: {node: '>=18'}
 
-  '@scure/base@1.1.1':
-    resolution: {integrity: sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==}
+  '@scure/base@1.2.4':
+    resolution: {integrity: sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ==}
 
   '@sinclair/typebox@0.25.24':
     resolution: {integrity: sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==}
@@ -1100,15 +1122,23 @@ packages:
     resolution: {integrity: sha512-CX6t4SYQ37lzxicAqsBtxA3OseeoVrh9cSJ5PFYam0GksYlupRfy1A+Q4aYD3zvcfECLc0zO2u+ZnR2UYKvCrw==}
     engines: {node: '>=14.16'}
 
-  '@substrate/connect-extension-protocol@1.0.1':
-    resolution: {integrity: sha512-161JhCC1csjH3GE5mPLEd7HbWtwNSPJBg3p1Ksz9SFlTzj/bgEwudiRN2y5i0MoLGCIJRYKyKGMxVnd29PzNjg==}
+  '@substrate/connect-extension-protocol@2.2.1':
+    resolution: {integrity: sha512-GoafTgm/Jey9E4Xlj4Z5ZBt/H4drH2CNq8VrAro80rtoznrXnFDNVivLQzZN0Xaj2g8YXSn9pC9Oc9IovYZJXw==}
 
-  '@substrate/connect@0.7.26':
-    resolution: {integrity: sha512-uuGSiroGuKWj1+38n1kY5HReer5iL9bRwPCzuoLtqAOmI1fGI0hsSI2LlNQMAbfRgr7VRHXOk5MTuQf5ulsFRw==}
+  '@substrate/connect-known-chains@1.9.1':
+    resolution: {integrity: sha512-dWNf5x3hjrY4s+WEovPKL0jH58pyIaIiAM918aAdnp/VKkAMqOfhKzRWL7BqJDKCm95bL4fqnOfaXZ3SQpVoYw==}
+
+  '@substrate/connect@0.8.10':
+    resolution: {integrity: sha512-DIyQ13DDlXqVFnLV+S6/JDgiGowVRRrh18kahieJxhgvzcWicw5eLc6jpfQ0moVVLBYkO7rctB5Wreldwpva8w==}
     deprecated: versions below 1.x are no longer maintained
 
-  '@substrate/ss58-registry@1.40.0':
-    resolution: {integrity: sha512-QuU2nBql3J4KCnOWtWDw4n1K4JU0T79j54ZZvm/9nhsX6AIar13FyhsaBfs6QkJ2ixTQAnd7TocJIoJRWbqMZA==}
+  '@substrate/light-client-extension-helpers@0.0.6':
+    resolution: {integrity: sha512-girltEuxQ1BvkJWmc8JJlk4ZxnlGXc/wkLcNguhY+UoDEMBK0LsdtfzQKIfrIehi4QdeSBlFEFBoI4RqPmsZzA==}
+    peerDependencies:
+      smoldot: 2.x
+
+  '@substrate/ss58-registry@1.51.0':
+    resolution: {integrity: sha512-TWDurLiPxndFgKjVavCniytBIw+t4ViOi7TYp9h/D0NMmkEc9klFTo+827eyEJ0lELpqO207Ey7uGxUa+BS1jQ==}
 
   '@szmarczak/http-timer@5.0.1':
     resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
@@ -2344,6 +2374,16 @@ packages:
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
 
+  eslint-plugin-unused-imports@3.2.0:
+    resolution: {integrity: sha512-6uXyn6xdINEpxE1MtDjxQsyXB37lfyO2yKGVVgtD7WEWQGORSOZjgrD6hBhvGv4/SO+TOlS+UnC6JppRqbuwGQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': 6 - 7
+      eslint: '8'
+    peerDependenciesMeta:
+      '@typescript-eslint/eslint-plugin':
+        optional: true
+
   eslint-plugin-vitest@0.4.1:
     resolution: {integrity: sha512-+PnZ2u/BS+f5FiuHXz4zKsHPcMKHie+K+1Uvu/x91ovkCMEOJqEI8E9Tw1Wzx2QRz4MHOBHYf1ypO8N1K0aNAA==}
     engines: {node: ^18.0.0 || >= 20.0.0}
@@ -2357,6 +2397,10 @@ packages:
       vitest:
         optional: true
 
+  eslint-rule-composer@0.3.0:
+    resolution: {integrity: sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==}
+    engines: {node: '>=4.0.0'}
+
   eslint-scope@7.2.2:
     resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -2368,6 +2412,7 @@ packages:
   eslint@8.57.0:
     resolution: {integrity: sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
   espree@9.6.1:
@@ -2408,9 +2453,6 @@ packages:
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
-
-  eventemitter3@4.0.7:
-    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
 
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
@@ -3456,8 +3498,8 @@ packages:
   mlly@1.4.0:
     resolution: {integrity: sha512-ua8PAThnTwpprIaU47EPeZ/bPUVp2QYBbWMphUQpVdBI3Lgqzm5KZQ45Agm3YJedHXaIHl6pBGabaLSUPPSptg==}
 
-  mock-socket@9.2.1:
-    resolution: {integrity: sha512-aw9F9T9G2zpGipLLhSNh6ZpgUyUl4frcVmRN08uE1NWPWg43Wx6+sGPDbQ7E5iFZZDJW5b5bypMeAEHqTbIFag==}
+  mock-socket@9.3.1:
+    resolution: {integrity: sha512-qxBgB7Qa2sEQgHFjj0dSigq7fX4k6Saisd5Nelwp2q8mlbAFh5dHV9JTTlF8viYJLSSWgMCZFUom8PJcMNBoJw==}
     engines: {node: '>= 8'}
 
   moment-timezone@0.5.43:
@@ -3507,8 +3549,8 @@ packages:
   nlcst-to-string@3.1.1:
     resolution: {integrity: sha512-63mVyqaqt0cmn2VcI2aH6kxe1rLAmSROqHMA0i4qqg1tidkfExgpb0FGMikMCn86mw5dFtBtEANfmSSK7TjNHw==}
 
-  nock@13.3.1:
-    resolution: {integrity: sha512-vHnopocZuI93p2ccivFyGuUfzjq2fxNyNurp7816mlT5V5HF4SzXu8lvLrVzBbNqzs+ODooZ6OksuSUNM7Njkw==}
+  nock@13.5.6:
+    resolution: {integrity: sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==}
     engines: {node: '>= 10.13'}
 
   node-abi@3.47.0:
@@ -3531,8 +3573,8 @@ packages:
       encoding:
         optional: true
 
-  node-fetch@3.3.1:
-    resolution: {integrity: sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==}
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-releases@2.0.14:
@@ -3661,9 +3703,6 @@ packages:
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
-
-  pako@2.1.0:
-    resolution: {integrity: sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -4167,6 +4206,9 @@ packages:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
 
+  scale-ts@1.6.1:
+    resolution: {integrity: sha512-PBMc2AWc6wSEqJYBDPcyCLUj9/tMKnLX70jLOSndMtcUoLQucP/DM0vnQo1wJAYjTrQiq8iG9rD0q6wFzgjH7g==}
+
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
@@ -4311,8 +4353,8 @@ packages:
     resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
     engines: {node: '>=10'}
 
-  smoldot@1.0.4:
-    resolution: {integrity: sha512-N3TazI1C4GGrseFH/piWyZCCCRJTRx2QhDfrUKRT4SzILlW5m8ayZ3QTKICcz1C/536T9cbHHJyP7afxI6Mi1A==}
+  smoldot@2.0.22:
+    resolution: {integrity: sha512-B50vRgTY6v3baYH6uCgL15tfaag5tcS2o/P5q1OiXcKGv1axZDfz2dzzMuIkVpyMR2ug11F6EAtQlmYBQd292g==}
 
   sonic-boom@3.7.0:
     resolution: {integrity: sha512-IudtNvSqA/ObjN97tfgNmOKyDOs4dNcg4cUUsHDebqsgb8wGBBwb31LIgShNO8fye0dFI52X1+tFoKKI6Rq1Gg==}
@@ -4627,8 +4669,8 @@ packages:
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
-  tslib@2.6.2:
-    resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tsutils@3.21.0:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
@@ -5476,7 +5518,7 @@ snapshots:
 
   '@emnapi/runtime@1.2.0':
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.8.1
     optional: true
 
   '@esbuild/android-arm64@0.18.16':
@@ -5742,125 +5784,149 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.0
       '@jridgewell/sourcemap-codec': 1.4.15
 
-  '@kiltprotocol/asset-did@0.35.2':
+  '@kiltprotocol/asset-did@0.36.0-rc.1':
     dependencies:
-      '@kiltprotocol/types': 0.35.2
-      '@kiltprotocol/utils': 0.35.2
+      '@kiltprotocol/types': 0.36.0-rc.1
+      '@kiltprotocol/utils': 0.36.0-rc.1
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@kiltprotocol/augment-api@0.35.2':
+  '@kiltprotocol/augment-api@1.11501.0-peregrine(@kiltprotocol/type-definitions@1.11501.0-peregrine(@polkadot/types@11.3.1))(@polkadot/api@11.3.1)(@polkadot/types@11.3.1)(typescript@5.4.5)':
     dependencies:
-      '@kiltprotocol/type-definitions': 0.35.2
+      '@polkadot/api': 11.3.1
+      typescript: 5.4.5
+    optionalDependencies:
+      '@kiltprotocol/type-definitions': 1.11501.0-peregrine(@polkadot/types@11.3.1)
+      '@polkadot/types': 11.3.1
+      '@typescript-eslint/eslint-plugin': 7.2.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/parser': 7.2.0(eslint@8.57.0)(typescript@5.4.5)
+      dotenv: 16.4.7
+      eslint: 8.57.0
+      eslint-plugin-unused-imports: 3.2.0(@typescript-eslint/eslint-plugin@7.2.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)
+    transitivePeerDependencies:
+      - supports-color
 
-  '@kiltprotocol/chain-helpers@0.35.2':
+  '@kiltprotocol/chain-helpers@0.36.0-rc.1':
     dependencies:
-      '@kiltprotocol/config': 0.35.2
-      '@kiltprotocol/types': 0.35.2
-      '@kiltprotocol/utils': 0.35.2
-      '@polkadot/api': 10.9.1
-      '@polkadot/types': 10.9.1
+      '@kiltprotocol/config': 0.36.0-rc.1
+      '@kiltprotocol/types': 0.36.0-rc.1
+      '@kiltprotocol/utils': 0.36.0-rc.1
+      '@polkadot/api': 11.3.1
+      '@polkadot/types': 11.3.1
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@kiltprotocol/config@0.35.2':
+  '@kiltprotocol/config@0.36.0-rc.1':
     dependencies:
-      '@kiltprotocol/types': 0.35.2
-      '@polkadot/api': 10.9.1
+      '@kiltprotocol/types': 0.36.0-rc.1
+      '@polkadot/api': 11.3.1
       typescript-logging: 1.0.1
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@kiltprotocol/core@0.35.2':
+  '@kiltprotocol/core@0.36.0-rc.1(typescript@5.4.5)':
     dependencies:
-      '@kiltprotocol/asset-did': 0.35.2
-      '@kiltprotocol/augment-api': 0.35.2
-      '@kiltprotocol/chain-helpers': 0.35.2
-      '@kiltprotocol/config': 0.35.2
-      '@kiltprotocol/did': 0.35.2
-      '@kiltprotocol/type-definitions': 0.35.2
-      '@kiltprotocol/types': 0.35.2
-      '@kiltprotocol/utils': 0.35.2
-      '@polkadot/api': 10.9.1
-      '@polkadot/keyring': 12.3.2(@polkadot/util-crypto@12.3.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2)
-      '@polkadot/types': 10.9.1
+      '@kiltprotocol/asset-did': 0.36.0-rc.1
+      '@kiltprotocol/augment-api': 1.11501.0-peregrine(@kiltprotocol/type-definitions@1.11501.0-peregrine(@polkadot/types@11.3.1))(@polkadot/api@11.3.1)(@polkadot/types@11.3.1)(typescript@5.4.5)
+      '@kiltprotocol/chain-helpers': 0.36.0-rc.1
+      '@kiltprotocol/config': 0.36.0-rc.1
+      '@kiltprotocol/did': 0.36.0-rc.1(@kiltprotocol/type-definitions@1.11501.0-peregrine(@polkadot/types@11.3.1))(typescript@5.4.5)
+      '@kiltprotocol/type-definitions': 1.11501.0-peregrine(@polkadot/types@11.3.1)
+      '@kiltprotocol/types': 0.36.0-rc.1
+      '@kiltprotocol/utils': 0.36.0-rc.1
+      '@polkadot/api': 11.3.1
+      '@polkadot/keyring': 12.6.2(@polkadot/util-crypto@12.6.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2)
+      '@polkadot/types': 11.3.1
       '@polkadot/util': 12.6.2
-      '@polkadot/util-crypto': 12.3.2(@polkadot/util@12.6.2)
+      '@polkadot/util-crypto': 12.6.2(@polkadot/util@12.6.2)
+    transitivePeerDependencies:
+      - '@polkadot/typegen'
+      - bufferutil
+      - supports-color
+      - typescript
+      - utf-8-validate
+
+  '@kiltprotocol/did@0.36.0-rc.1(@kiltprotocol/type-definitions@1.11501.0-peregrine(@polkadot/types@11.3.1))(typescript@5.4.5)':
+    dependencies:
+      '@kiltprotocol/augment-api': 1.11501.0-peregrine(@kiltprotocol/type-definitions@1.11501.0-peregrine(@polkadot/types@11.3.1))(@polkadot/api@11.3.1)(@polkadot/types@11.3.1)(typescript@5.4.5)
+      '@kiltprotocol/config': 0.36.0-rc.1
+      '@kiltprotocol/types': 0.36.0-rc.1
+      '@kiltprotocol/utils': 0.36.0-rc.1
+      '@polkadot/api': 11.3.1
+      '@polkadot/keyring': 12.6.2(@polkadot/util-crypto@12.6.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2)
+      '@polkadot/types': 11.3.1
+      '@polkadot/types-codec': 11.3.1
+      '@polkadot/util': 12.6.2
+      '@polkadot/util-crypto': 12.6.2(@polkadot/util@12.6.2)
+    transitivePeerDependencies:
+      - '@kiltprotocol/type-definitions'
+      - '@polkadot/typegen'
+      - bufferutil
+      - supports-color
+      - typescript
+      - utf-8-validate
+
+  '@kiltprotocol/messaging@0.36.0-rc.1(@kiltprotocol/type-definitions@1.11501.0-peregrine(@polkadot/types@11.3.1))(typescript@5.4.5)':
+    dependencies:
+      '@kiltprotocol/core': 0.36.0-rc.1(typescript@5.4.5)
+      '@kiltprotocol/did': 0.36.0-rc.1(@kiltprotocol/type-definitions@1.11501.0-peregrine(@polkadot/types@11.3.1))(typescript@5.4.5)
+      '@kiltprotocol/types': 0.36.0-rc.1
+      '@kiltprotocol/utils': 0.36.0-rc.1
+      '@polkadot/util': 12.6.2
+    transitivePeerDependencies:
+      - '@kiltprotocol/type-definitions'
+      - '@polkadot/typegen'
+      - bufferutil
+      - supports-color
+      - typescript
+      - utf-8-validate
+
+  '@kiltprotocol/sdk-js@0.36.0-rc.1(@kiltprotocol/type-definitions@1.11501.0-peregrine(@polkadot/types@11.3.1))(typescript@5.4.5)':
+    dependencies:
+      '@kiltprotocol/chain-helpers': 0.36.0-rc.1
+      '@kiltprotocol/config': 0.36.0-rc.1
+      '@kiltprotocol/core': 0.36.0-rc.1(typescript@5.4.5)
+      '@kiltprotocol/did': 0.36.0-rc.1(@kiltprotocol/type-definitions@1.11501.0-peregrine(@polkadot/types@11.3.1))(typescript@5.4.5)
+      '@kiltprotocol/messaging': 0.36.0-rc.1(@kiltprotocol/type-definitions@1.11501.0-peregrine(@polkadot/types@11.3.1))(typescript@5.4.5)
+      '@kiltprotocol/types': 0.36.0-rc.1
+      '@kiltprotocol/utils': 0.36.0-rc.1
+    transitivePeerDependencies:
+      - '@kiltprotocol/type-definitions'
+      - '@polkadot/typegen'
+      - bufferutil
+      - supports-color
+      - typescript
+      - utf-8-validate
+
+  '@kiltprotocol/type-definitions@1.11501.0-peregrine(@polkadot/types@11.3.1)':
+    dependencies:
+      '@polkadot/types': 11.3.1
+
+  '@kiltprotocol/types@0.36.0-rc.1':
+    dependencies:
+      '@polkadot/api': 11.3.1
+      '@polkadot/keyring': 12.6.2(@polkadot/util-crypto@12.6.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2)
+      '@polkadot/types': 11.3.1
+      '@polkadot/util': 12.6.2
+      '@polkadot/util-crypto': 12.6.2(@polkadot/util@12.6.2)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@kiltprotocol/did@0.35.2':
+  '@kiltprotocol/utils@0.36.0-rc.1':
     dependencies:
-      '@kiltprotocol/augment-api': 0.35.2
-      '@kiltprotocol/config': 0.35.2
-      '@kiltprotocol/types': 0.35.2
-      '@kiltprotocol/utils': 0.35.2
-      '@polkadot/api': 10.9.1
-      '@polkadot/keyring': 12.3.2(@polkadot/util-crypto@12.3.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2)
-      '@polkadot/types': 10.9.1
-      '@polkadot/types-codec': 10.9.1
+      '@kiltprotocol/types': 0.36.0-rc.1
+      '@polkadot/api': 11.3.1
+      '@polkadot/keyring': 12.6.2(@polkadot/util-crypto@12.6.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2)
       '@polkadot/util': 12.6.2
-      '@polkadot/util-crypto': 12.3.2(@polkadot/util@12.6.2)
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  '@kiltprotocol/messaging@0.35.2':
-    dependencies:
-      '@kiltprotocol/core': 0.35.2
-      '@kiltprotocol/did': 0.35.2
-      '@kiltprotocol/types': 0.35.2
-      '@kiltprotocol/utils': 0.35.2
-      '@polkadot/util': 12.6.2
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  '@kiltprotocol/sdk-js@0.35.2':
-    dependencies:
-      '@kiltprotocol/chain-helpers': 0.35.2
-      '@kiltprotocol/config': 0.35.2
-      '@kiltprotocol/core': 0.35.2
-      '@kiltprotocol/did': 0.35.2
-      '@kiltprotocol/messaging': 0.35.2
-      '@kiltprotocol/types': 0.35.2
-      '@kiltprotocol/utils': 0.35.2
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  '@kiltprotocol/type-definitions@0.35.2': {}
-
-  '@kiltprotocol/types@0.35.2':
-    dependencies:
-      '@polkadot/api': 10.9.1
-      '@polkadot/keyring': 12.3.2(@polkadot/util-crypto@12.3.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2)
-      '@polkadot/types': 10.9.1
-      '@polkadot/util': 12.6.2
-      '@polkadot/util-crypto': 12.3.2(@polkadot/util@12.6.2)
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  '@kiltprotocol/utils@0.35.2':
-    dependencies:
-      '@kiltprotocol/types': 0.35.2
-      '@polkadot/api': 10.9.1
-      '@polkadot/keyring': 12.3.2(@polkadot/util-crypto@12.3.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2)
-      '@polkadot/util': 12.6.2
-      '@polkadot/util-crypto': 12.3.2(@polkadot/util@12.6.2)
+      '@polkadot/util-crypto': 12.6.2(@polkadot/util@12.6.2)
       cbor-web: 9.0.1
       tweetnacl: 1.0.3
       uuid: 9.0.0
@@ -5869,11 +5935,11 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@noble/curves@1.1.0':
+  '@noble/curves@1.8.1':
     dependencies:
-      '@noble/hashes': 1.3.1
+      '@noble/hashes': 1.7.1
 
-  '@noble/hashes@1.3.1': {}
+  '@noble/hashes@1.7.1': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -5894,225 +5960,250 @@ snapshots:
       is-glob: 4.0.3
       open: 9.1.0
       picocolors: 1.0.1
-      tslib: 2.6.2
+      tslib: 2.8.1
 
-  '@polkadot/api-augment@10.9.1':
+  '@polkadot-api/json-rpc-provider-proxy@0.0.1':
+    optional: true
+
+  '@polkadot-api/json-rpc-provider@0.0.1':
+    optional: true
+
+  '@polkadot-api/metadata-builders@0.0.1':
     dependencies:
-      '@polkadot/api-base': 10.9.1
-      '@polkadot/rpc-augment': 10.9.1
-      '@polkadot/types': 10.9.1
-      '@polkadot/types-augment': 10.9.1
-      '@polkadot/types-codec': 10.9.1
+      '@polkadot-api/substrate-bindings': 0.0.1
+      '@polkadot-api/utils': 0.0.1
+    optional: true
+
+  '@polkadot-api/observable-client@0.1.0(rxjs@7.8.1)':
+    dependencies:
+      '@polkadot-api/metadata-builders': 0.0.1
+      '@polkadot-api/substrate-bindings': 0.0.1
+      '@polkadot-api/substrate-client': 0.0.1
+      '@polkadot-api/utils': 0.0.1
+      rxjs: 7.8.1
+    optional: true
+
+  '@polkadot-api/substrate-bindings@0.0.1':
+    dependencies:
+      '@noble/hashes': 1.7.1
+      '@polkadot-api/utils': 0.0.1
+      '@scure/base': 1.2.4
+      scale-ts: 1.6.1
+    optional: true
+
+  '@polkadot-api/substrate-client@0.0.1':
+    optional: true
+
+  '@polkadot-api/utils@0.0.1':
+    optional: true
+
+  '@polkadot/api-augment@11.3.1':
+    dependencies:
+      '@polkadot/api-base': 11.3.1
+      '@polkadot/rpc-augment': 11.3.1
+      '@polkadot/types': 11.3.1
+      '@polkadot/types-augment': 11.3.1
+      '@polkadot/types-codec': 11.3.1
       '@polkadot/util': 12.6.2
-      tslib: 2.6.2
+      tslib: 2.8.1
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@polkadot/api-base@10.9.1':
+  '@polkadot/api-base@11.3.1':
     dependencies:
-      '@polkadot/rpc-core': 10.9.1
-      '@polkadot/types': 10.9.1
+      '@polkadot/rpc-core': 11.3.1
+      '@polkadot/types': 11.3.1
       '@polkadot/util': 12.6.2
       rxjs: 7.8.1
-      tslib: 2.6.2
+      tslib: 2.8.1
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@polkadot/api-derive@10.9.1':
+  '@polkadot/api-derive@11.3.1':
     dependencies:
-      '@polkadot/api': 10.9.1
-      '@polkadot/api-augment': 10.9.1
-      '@polkadot/api-base': 10.9.1
-      '@polkadot/rpc-core': 10.9.1
-      '@polkadot/types': 10.9.1
-      '@polkadot/types-codec': 10.9.1
+      '@polkadot/api': 11.3.1
+      '@polkadot/api-augment': 11.3.1
+      '@polkadot/api-base': 11.3.1
+      '@polkadot/rpc-core': 11.3.1
+      '@polkadot/types': 11.3.1
+      '@polkadot/types-codec': 11.3.1
       '@polkadot/util': 12.6.2
-      '@polkadot/util-crypto': 12.3.2(@polkadot/util@12.6.2)
+      '@polkadot/util-crypto': 12.6.2(@polkadot/util@12.6.2)
       rxjs: 7.8.1
-      tslib: 2.6.2
+      tslib: 2.8.1
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@polkadot/api@10.9.1':
+  '@polkadot/api@11.3.1':
     dependencies:
-      '@polkadot/api-augment': 10.9.1
-      '@polkadot/api-base': 10.9.1
-      '@polkadot/api-derive': 10.9.1
-      '@polkadot/keyring': 12.3.2(@polkadot/util-crypto@12.3.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2)
-      '@polkadot/rpc-augment': 10.9.1
-      '@polkadot/rpc-core': 10.9.1
-      '@polkadot/rpc-provider': 10.9.1
-      '@polkadot/types': 10.9.1
-      '@polkadot/types-augment': 10.9.1
-      '@polkadot/types-codec': 10.9.1
-      '@polkadot/types-create': 10.9.1
-      '@polkadot/types-known': 10.9.1
+      '@polkadot/api-augment': 11.3.1
+      '@polkadot/api-base': 11.3.1
+      '@polkadot/api-derive': 11.3.1
+      '@polkadot/keyring': 12.6.2(@polkadot/util-crypto@12.6.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2)
+      '@polkadot/rpc-augment': 11.3.1
+      '@polkadot/rpc-core': 11.3.1
+      '@polkadot/rpc-provider': 11.3.1
+      '@polkadot/types': 11.3.1
+      '@polkadot/types-augment': 11.3.1
+      '@polkadot/types-codec': 11.3.1
+      '@polkadot/types-create': 11.3.1
+      '@polkadot/types-known': 11.3.1
       '@polkadot/util': 12.6.2
-      '@polkadot/util-crypto': 12.3.2(@polkadot/util@12.6.2)
+      '@polkadot/util-crypto': 12.6.2(@polkadot/util@12.6.2)
       eventemitter3: 5.0.1
       rxjs: 7.8.1
-      tslib: 2.6.2
+      tslib: 2.8.1
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@polkadot/extension-dapp@0.46.5(@polkadot/api@10.9.1)(@polkadot/util-crypto@12.3.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2)':
+  '@polkadot/extension-dapp@0.47.6(@polkadot/api@11.3.1)(@polkadot/util-crypto@12.6.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2)':
     dependencies:
-      '@polkadot/api': 10.9.1
-      '@polkadot/extension-inject': 0.46.5(@polkadot/api@10.9.1)(@polkadot/util@12.6.2)
+      '@polkadot/api': 11.3.1
+      '@polkadot/extension-inject': 0.47.6(@polkadot/api@11.3.1)(@polkadot/util@12.6.2)
       '@polkadot/util': 12.6.2
-      '@polkadot/util-crypto': 12.3.2(@polkadot/util@12.6.2)
-      tslib: 2.6.2
+      '@polkadot/util-crypto': 12.6.2(@polkadot/util@12.6.2)
+      tslib: 2.8.1
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@polkadot/extension-inject@0.46.5(@polkadot/api@10.9.1)(@polkadot/util@12.6.2)':
+  '@polkadot/extension-inject@0.47.6(@polkadot/api@11.3.1)(@polkadot/util@12.6.2)':
     dependencies:
-      '@polkadot/api': 10.9.1
-      '@polkadot/rpc-provider': 10.9.1
-      '@polkadot/types': 10.9.1
+      '@polkadot/api': 11.3.1
+      '@polkadot/rpc-provider': 11.3.1
+      '@polkadot/types': 11.3.1
       '@polkadot/util': 12.6.2
-      '@polkadot/util-crypto': 12.3.2(@polkadot/util@12.6.2)
+      '@polkadot/util-crypto': 12.6.2(@polkadot/util@12.6.2)
       '@polkadot/x-global': 12.6.2
-      tslib: 2.6.2
+      tslib: 2.8.1
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@polkadot/keyring@12.3.2(@polkadot/util-crypto@12.3.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2)':
+  '@polkadot/keyring@12.6.2(@polkadot/util-crypto@12.6.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2)':
     dependencies:
       '@polkadot/util': 12.6.2
-      '@polkadot/util-crypto': 12.3.2(@polkadot/util@12.6.2)
-      tslib: 2.6.2
+      '@polkadot/util-crypto': 12.6.2(@polkadot/util@12.6.2)
+      tslib: 2.8.1
 
-  '@polkadot/networks@12.3.2':
+  '@polkadot/networks@12.6.2':
     dependencies:
-      '@polkadot/util': 12.3.2
-      '@substrate/ss58-registry': 1.40.0
-      tslib: 2.6.2
-
-  '@polkadot/rpc-augment@10.9.1':
-    dependencies:
-      '@polkadot/rpc-core': 10.9.1
-      '@polkadot/types': 10.9.1
-      '@polkadot/types-codec': 10.9.1
       '@polkadot/util': 12.6.2
-      tslib: 2.6.2
+      '@substrate/ss58-registry': 1.51.0
+      tslib: 2.8.1
+
+  '@polkadot/rpc-augment@11.3.1':
+    dependencies:
+      '@polkadot/rpc-core': 11.3.1
+      '@polkadot/types': 11.3.1
+      '@polkadot/types-codec': 11.3.1
+      '@polkadot/util': 12.6.2
+      tslib: 2.8.1
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@polkadot/rpc-core@10.9.1':
+  '@polkadot/rpc-core@11.3.1':
     dependencies:
-      '@polkadot/rpc-augment': 10.9.1
-      '@polkadot/rpc-provider': 10.9.1
-      '@polkadot/types': 10.9.1
+      '@polkadot/rpc-augment': 11.3.1
+      '@polkadot/rpc-provider': 11.3.1
+      '@polkadot/types': 11.3.1
       '@polkadot/util': 12.6.2
       rxjs: 7.8.1
-      tslib: 2.6.2
+      tslib: 2.8.1
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@polkadot/rpc-provider@10.9.1':
+  '@polkadot/rpc-provider@11.3.1':
     dependencies:
-      '@polkadot/keyring': 12.3.2(@polkadot/util-crypto@12.3.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2)
-      '@polkadot/types': 10.9.1
-      '@polkadot/types-support': 10.9.1
+      '@polkadot/keyring': 12.6.2(@polkadot/util-crypto@12.6.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2)
+      '@polkadot/types': 11.3.1
+      '@polkadot/types-support': 11.3.1
       '@polkadot/util': 12.6.2
-      '@polkadot/util-crypto': 12.3.2(@polkadot/util@12.6.2)
-      '@polkadot/x-fetch': 12.3.2
+      '@polkadot/util-crypto': 12.6.2(@polkadot/util@12.6.2)
+      '@polkadot/x-fetch': 12.6.2
       '@polkadot/x-global': 12.6.2
-      '@polkadot/x-ws': 12.3.2
+      '@polkadot/x-ws': 12.6.2
       eventemitter3: 5.0.1
-      mock-socket: 9.2.1
-      nock: 13.3.1
-      tslib: 2.6.2
+      mock-socket: 9.3.1
+      nock: 13.5.6
+      tslib: 2.8.1
     optionalDependencies:
-      '@substrate/connect': 0.7.26
+      '@substrate/connect': 0.8.10
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@polkadot/types-augment@10.9.1':
+  '@polkadot/types-augment@11.3.1':
     dependencies:
-      '@polkadot/types': 10.9.1
-      '@polkadot/types-codec': 10.9.1
+      '@polkadot/types': 11.3.1
+      '@polkadot/types-codec': 11.3.1
       '@polkadot/util': 12.6.2
-      tslib: 2.6.2
+      tslib: 2.8.1
 
-  '@polkadot/types-codec@10.9.1':
+  '@polkadot/types-codec@11.3.1':
     dependencies:
       '@polkadot/util': 12.6.2
       '@polkadot/x-bigint': 12.6.2
-      tslib: 2.6.2
+      tslib: 2.8.1
 
-  '@polkadot/types-create@10.9.1':
+  '@polkadot/types-create@11.3.1':
     dependencies:
-      '@polkadot/types-codec': 10.9.1
+      '@polkadot/types-codec': 11.3.1
       '@polkadot/util': 12.6.2
-      tslib: 2.6.2
+      tslib: 2.8.1
 
-  '@polkadot/types-known@10.9.1':
+  '@polkadot/types-known@11.3.1':
     dependencies:
-      '@polkadot/networks': 12.3.2
-      '@polkadot/types': 10.9.1
-      '@polkadot/types-codec': 10.9.1
-      '@polkadot/types-create': 10.9.1
+      '@polkadot/networks': 12.6.2
+      '@polkadot/types': 11.3.1
+      '@polkadot/types-codec': 11.3.1
+      '@polkadot/types-create': 11.3.1
       '@polkadot/util': 12.6.2
-      tslib: 2.6.2
+      tslib: 2.8.1
 
-  '@polkadot/types-support@10.9.1':
+  '@polkadot/types-support@11.3.1':
     dependencies:
       '@polkadot/util': 12.6.2
-      tslib: 2.6.2
+      tslib: 2.8.1
 
-  '@polkadot/types@10.9.1':
+  '@polkadot/types@11.3.1':
     dependencies:
-      '@polkadot/keyring': 12.3.2(@polkadot/util-crypto@12.3.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2)
-      '@polkadot/types-augment': 10.9.1
-      '@polkadot/types-codec': 10.9.1
-      '@polkadot/types-create': 10.9.1
+      '@polkadot/keyring': 12.6.2(@polkadot/util-crypto@12.6.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2)
+      '@polkadot/types-augment': 11.3.1
+      '@polkadot/types-codec': 11.3.1
+      '@polkadot/types-create': 11.3.1
       '@polkadot/util': 12.6.2
-      '@polkadot/util-crypto': 12.3.2(@polkadot/util@12.6.2)
+      '@polkadot/util-crypto': 12.6.2(@polkadot/util@12.6.2)
       rxjs: 7.8.1
-      tslib: 2.6.2
+      tslib: 2.8.1
 
-  '@polkadot/util-crypto@12.3.2(@polkadot/util@12.6.2)':
+  '@polkadot/util-crypto@12.6.2(@polkadot/util@12.6.2)':
     dependencies:
-      '@noble/curves': 1.1.0
-      '@noble/hashes': 1.3.1
-      '@polkadot/networks': 12.3.2
+      '@noble/curves': 1.8.1
+      '@noble/hashes': 1.7.1
+      '@polkadot/networks': 12.6.2
       '@polkadot/util': 12.6.2
-      '@polkadot/wasm-crypto': 7.2.1(@polkadot/util@12.6.2)(@polkadot/x-randomvalues@12.3.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.2.1(@polkadot/util@12.6.2)))
-      '@polkadot/wasm-util': 7.2.1(@polkadot/util@12.6.2)
-      '@polkadot/x-bigint': 12.3.2
-      '@polkadot/x-randomvalues': 12.3.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.2.1(@polkadot/util@12.6.2))
-      '@scure/base': 1.1.1
-      tslib: 2.6.2
-
-  '@polkadot/util@12.3.2':
-    dependencies:
-      '@polkadot/x-bigint': 12.3.2
-      '@polkadot/x-global': 12.3.2
-      '@polkadot/x-textdecoder': 12.3.2
-      '@polkadot/x-textencoder': 12.3.2
-      '@types/bn.js': 5.1.5
-      bn.js: 5.2.1
-      tslib: 2.6.2
+      '@polkadot/wasm-crypto': 7.4.1(@polkadot/util@12.6.2)(@polkadot/x-randomvalues@12.6.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.4.1(@polkadot/util@12.6.2)))
+      '@polkadot/wasm-util': 7.4.1(@polkadot/util@12.6.2)
+      '@polkadot/x-bigint': 12.6.2
+      '@polkadot/x-randomvalues': 12.6.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.4.1(@polkadot/util@12.6.2))
+      '@scure/base': 1.2.4
+      tslib: 2.8.1
 
   '@polkadot/util@12.6.2':
     dependencies:
@@ -6122,132 +6213,129 @@ snapshots:
       '@polkadot/x-textencoder': 12.6.2
       '@types/bn.js': 5.1.5
       bn.js: 5.2.1
-      tslib: 2.6.2
+      tslib: 2.8.1
 
-  '@polkadot/wasm-bridge@7.2.1(@polkadot/util@12.6.2)(@polkadot/x-randomvalues@12.3.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.2.1(@polkadot/util@12.6.2)))':
+  '@polkadot/wasm-bridge@7.4.1(@polkadot/util@12.6.2)(@polkadot/x-randomvalues@12.6.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.4.1(@polkadot/util@12.6.2)))':
     dependencies:
       '@polkadot/util': 12.6.2
-      '@polkadot/wasm-util': 7.2.1(@polkadot/util@12.6.2)
-      '@polkadot/x-randomvalues': 12.3.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.2.1(@polkadot/util@12.6.2))
-      tslib: 2.6.2
+      '@polkadot/wasm-util': 7.4.1(@polkadot/util@12.6.2)
+      '@polkadot/x-randomvalues': 12.6.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.4.1(@polkadot/util@12.6.2))
+      tslib: 2.8.1
 
-  '@polkadot/wasm-crypto-asmjs@7.2.1(@polkadot/util@12.6.2)':
+  '@polkadot/wasm-crypto-asmjs@7.4.1(@polkadot/util@12.6.2)':
     dependencies:
       '@polkadot/util': 12.6.2
-      tslib: 2.6.2
+      tslib: 2.8.1
 
-  '@polkadot/wasm-crypto-init@7.2.1(@polkadot/util@12.6.2)(@polkadot/x-randomvalues@12.3.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.2.1(@polkadot/util@12.6.2)))':
+  '@polkadot/wasm-crypto-init@7.4.1(@polkadot/util@12.6.2)(@polkadot/x-randomvalues@12.6.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.4.1(@polkadot/util@12.6.2)))':
     dependencies:
       '@polkadot/util': 12.6.2
-      '@polkadot/wasm-bridge': 7.2.1(@polkadot/util@12.6.2)(@polkadot/x-randomvalues@12.3.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.2.1(@polkadot/util@12.6.2)))
-      '@polkadot/wasm-crypto-asmjs': 7.2.1(@polkadot/util@12.6.2)
-      '@polkadot/wasm-crypto-wasm': 7.2.1(@polkadot/util@12.6.2)
-      '@polkadot/wasm-util': 7.2.1(@polkadot/util@12.6.2)
-      '@polkadot/x-randomvalues': 12.3.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.2.1(@polkadot/util@12.6.2))
-      tslib: 2.6.2
+      '@polkadot/wasm-bridge': 7.4.1(@polkadot/util@12.6.2)(@polkadot/x-randomvalues@12.6.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.4.1(@polkadot/util@12.6.2)))
+      '@polkadot/wasm-crypto-asmjs': 7.4.1(@polkadot/util@12.6.2)
+      '@polkadot/wasm-crypto-wasm': 7.4.1(@polkadot/util@12.6.2)
+      '@polkadot/wasm-util': 7.4.1(@polkadot/util@12.6.2)
+      '@polkadot/x-randomvalues': 12.6.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.4.1(@polkadot/util@12.6.2))
+      tslib: 2.8.1
 
-  '@polkadot/wasm-crypto-wasm@7.2.1(@polkadot/util@12.6.2)':
+  '@polkadot/wasm-crypto-wasm@7.4.1(@polkadot/util@12.6.2)':
     dependencies:
       '@polkadot/util': 12.6.2
-      '@polkadot/wasm-util': 7.2.1(@polkadot/util@12.6.2)
-      tslib: 2.6.2
+      '@polkadot/wasm-util': 7.4.1(@polkadot/util@12.6.2)
+      tslib: 2.8.1
 
-  '@polkadot/wasm-crypto@7.2.1(@polkadot/util@12.6.2)(@polkadot/x-randomvalues@12.3.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.2.1(@polkadot/util@12.6.2)))':
+  '@polkadot/wasm-crypto@7.4.1(@polkadot/util@12.6.2)(@polkadot/x-randomvalues@12.6.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.4.1(@polkadot/util@12.6.2)))':
     dependencies:
       '@polkadot/util': 12.6.2
-      '@polkadot/wasm-bridge': 7.2.1(@polkadot/util@12.6.2)(@polkadot/x-randomvalues@12.3.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.2.1(@polkadot/util@12.6.2)))
-      '@polkadot/wasm-crypto-asmjs': 7.2.1(@polkadot/util@12.6.2)
-      '@polkadot/wasm-crypto-init': 7.2.1(@polkadot/util@12.6.2)(@polkadot/x-randomvalues@12.3.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.2.1(@polkadot/util@12.6.2)))
-      '@polkadot/wasm-crypto-wasm': 7.2.1(@polkadot/util@12.6.2)
-      '@polkadot/wasm-util': 7.2.1(@polkadot/util@12.6.2)
-      '@polkadot/x-randomvalues': 12.3.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.2.1(@polkadot/util@12.6.2))
-      tslib: 2.6.2
+      '@polkadot/wasm-bridge': 7.4.1(@polkadot/util@12.6.2)(@polkadot/x-randomvalues@12.6.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.4.1(@polkadot/util@12.6.2)))
+      '@polkadot/wasm-crypto-asmjs': 7.4.1(@polkadot/util@12.6.2)
+      '@polkadot/wasm-crypto-init': 7.4.1(@polkadot/util@12.6.2)(@polkadot/x-randomvalues@12.6.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.4.1(@polkadot/util@12.6.2)))
+      '@polkadot/wasm-crypto-wasm': 7.4.1(@polkadot/util@12.6.2)
+      '@polkadot/wasm-util': 7.4.1(@polkadot/util@12.6.2)
+      '@polkadot/x-randomvalues': 12.6.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.4.1(@polkadot/util@12.6.2))
+      tslib: 2.8.1
 
-  '@polkadot/wasm-util@7.2.1(@polkadot/util@12.6.2)':
+  '@polkadot/wasm-util@7.4.1(@polkadot/util@12.6.2)':
     dependencies:
       '@polkadot/util': 12.6.2
-      tslib: 2.6.2
-
-  '@polkadot/x-bigint@12.3.2':
-    dependencies:
-      '@polkadot/x-global': 12.3.2
-      tslib: 2.6.2
+      tslib: 2.8.1
 
   '@polkadot/x-bigint@12.6.2':
     dependencies:
       '@polkadot/x-global': 12.6.2
-      tslib: 2.6.2
+      tslib: 2.8.1
 
-  '@polkadot/x-fetch@12.3.2':
+  '@polkadot/x-fetch@12.6.2':
     dependencies:
-      '@polkadot/x-global': 12.3.2
-      node-fetch: 3.3.1
-      tslib: 2.6.2
-
-  '@polkadot/x-global@12.3.2':
-    dependencies:
-      tslib: 2.6.2
+      '@polkadot/x-global': 12.6.2
+      node-fetch: 3.3.2
+      tslib: 2.8.1
 
   '@polkadot/x-global@12.6.2':
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.8.1
 
-  '@polkadot/x-randomvalues@12.3.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.2.1(@polkadot/util@12.6.2))':
+  '@polkadot/x-randomvalues@12.6.2(@polkadot/util@12.6.2)(@polkadot/wasm-util@7.4.1(@polkadot/util@12.6.2))':
     dependencies:
       '@polkadot/util': 12.6.2
-      '@polkadot/wasm-util': 7.2.1(@polkadot/util@12.6.2)
-      '@polkadot/x-global': 12.3.2
-      tslib: 2.6.2
-
-  '@polkadot/x-textdecoder@12.3.2':
-    dependencies:
-      '@polkadot/x-global': 12.3.2
-      tslib: 2.6.2
+      '@polkadot/wasm-util': 7.4.1(@polkadot/util@12.6.2)
+      '@polkadot/x-global': 12.6.2
+      tslib: 2.8.1
 
   '@polkadot/x-textdecoder@12.6.2':
     dependencies:
       '@polkadot/x-global': 12.6.2
-      tslib: 2.6.2
-
-  '@polkadot/x-textencoder@12.3.2':
-    dependencies:
-      '@polkadot/x-global': 12.3.2
-      tslib: 2.6.2
+      tslib: 2.8.1
 
   '@polkadot/x-textencoder@12.6.2':
     dependencies:
       '@polkadot/x-global': 12.6.2
-      tslib: 2.6.2
+      tslib: 2.8.1
 
-  '@polkadot/x-ws@12.3.2':
+  '@polkadot/x-ws@12.6.2':
     dependencies:
-      '@polkadot/x-global': 12.3.2
-      tslib: 2.6.2
+      '@polkadot/x-global': 12.6.2
+      tslib: 2.8.1
       ws: 8.18.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@scure/base@1.1.1': {}
+  '@scure/base@1.2.4': {}
 
   '@sinclair/typebox@0.25.24': {}
 
   '@sindresorhus/is@5.3.0': {}
 
-  '@substrate/connect-extension-protocol@1.0.1':
+  '@substrate/connect-extension-protocol@2.2.1':
     optional: true
 
-  '@substrate/connect@0.7.26':
+  '@substrate/connect-known-chains@1.9.1':
+    optional: true
+
+  '@substrate/connect@0.8.10':
     dependencies:
-      '@substrate/connect-extension-protocol': 1.0.1
-      eventemitter3: 4.0.7
-      smoldot: 1.0.4
+      '@substrate/connect-extension-protocol': 2.2.1
+      '@substrate/connect-known-chains': 1.9.1
+      '@substrate/light-client-extension-helpers': 0.0.6(smoldot@2.0.22)
+      smoldot: 2.0.22
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
     optional: true
 
-  '@substrate/ss58-registry@1.40.0': {}
+  '@substrate/light-client-extension-helpers@0.0.6(smoldot@2.0.22)':
+    dependencies:
+      '@polkadot-api/json-rpc-provider': 0.0.1
+      '@polkadot-api/json-rpc-provider-proxy': 0.0.1
+      '@polkadot-api/observable-client': 0.1.0(rxjs@7.8.1)
+      '@polkadot-api/substrate-client': 0.0.1
+      '@substrate/connect-extension-protocol': 2.2.1
+      '@substrate/connect-known-chains': 1.9.1
+      rxjs: 7.8.1
+      smoldot: 2.0.22
+    optional: true
+
+  '@substrate/ss58-registry@1.51.0': {}
 
   '@szmarczak/http-timer@5.0.1':
     dependencies:
@@ -7870,6 +7958,14 @@ snapshots:
       semver: 6.3.1
       string.prototype.matchall: 4.0.11
 
+  eslint-plugin-unused-imports@3.2.0(@typescript-eslint/eslint-plugin@7.2.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0):
+    dependencies:
+      eslint: 8.57.0
+      eslint-rule-composer: 0.3.0
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 7.2.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
+    optional: true
+
   eslint-plugin-vitest@0.4.1(@typescript-eslint/eslint-plugin@7.2.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)(vitest@0.34.6(jsdom@24.1.1)):
     dependencies:
       '@typescript-eslint/utils': 7.4.0(eslint@8.57.0)(typescript@5.4.5)
@@ -7880,6 +7976,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  eslint-rule-composer@0.3.0:
+    optional: true
 
   eslint-scope@7.2.2:
     dependencies:
@@ -7963,9 +8062,6 @@ snapshots:
       es5-ext: 0.10.62
 
   event-target-shim@5.0.1: {}
-
-  eventemitter3@4.0.7:
-    optional: true
 
   eventemitter3@5.0.1: {}
 
@@ -9258,7 +9354,7 @@ snapshots:
       pkg-types: 1.0.3
       ufo: 1.1.2
 
-  mock-socket@9.2.1: {}
+  mock-socket@9.3.1: {}
 
   moment-timezone@0.5.43:
     dependencies:
@@ -9300,11 +9396,10 @@ snapshots:
     dependencies:
       '@types/nlcst': 1.0.0
 
-  nock@13.3.1:
+  nock@13.5.6:
     dependencies:
       debug: 4.3.4
       json-stringify-safe: 5.0.1
-      lodash: 4.17.21
       propagate: 2.0.1
     transitivePeerDependencies:
       - supports-color
@@ -9323,7 +9418,7 @@ snapshots:
     dependencies:
       whatwg-url: 5.0.0
 
-  node-fetch@3.3.1:
+  node-fetch@3.3.2:
     dependencies:
       data-uri-to-buffer: 4.0.1
       fetch-blob: 3.2.0
@@ -9470,9 +9565,6 @@ snapshots:
   p-timeout@5.1.0: {}
 
   p-try@2.2.0: {}
-
-  pako@2.1.0:
-    optional: true
 
   parent-module@1.0.1:
     dependencies:
@@ -10002,7 +10094,7 @@ snapshots:
 
   rxjs@7.8.1:
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.8.1
 
   s.color@0.0.15: {}
 
@@ -10040,6 +10132,9 @@ snapshots:
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
+
+  scale-ts@1.6.1:
+    optional: true
 
   scheduler@0.23.2:
     dependencies:
@@ -10223,9 +10318,8 @@ snapshots:
       astral-regex: 2.0.0
       is-fullwidth-code-point: 3.0.0
 
-  smoldot@1.0.4:
+  smoldot@2.0.22:
     dependencies:
-      pako: 2.1.0
       ws: 8.18.0
     transitivePeerDependencies:
       - bufferutil
@@ -10496,7 +10590,7 @@ snapshots:
   synckit@0.8.6:
     dependencies:
       '@pkgr/utils': 2.4.2
-      tslib: 2.6.2
+      tslib: 2.8.1
 
   table@6.8.2:
     dependencies:
@@ -10633,7 +10727,7 @@ snapshots:
 
   tslib@1.14.1: {}
 
-  tslib@2.6.2: {}
+  tslib@2.8.1: {}
 
   tsutils@3.21.0(typescript@5.4.5):
     dependencies:

--- a/testing/endowAccount.ts
+++ b/testing/endowAccount.ts
@@ -9,7 +9,10 @@ import {
 export async function endowAccount(address: KiltAddress) {
   const api = ConfigService.get('api');
 
-  const tx = api.tx.balances.transfer(address, BalanceUtils.toFemtoKilt(1000));
+  const tx = api.tx.balances.transferKeepAlive(
+    address,
+    BalanceUtils.toFemtoKilt(1000),
+  );
   const faucet = Utils.Crypto.makeKeypairFromUri(
     'receive clutch item involve chaos clutch furnace arrest claw isolate okay together',
   );

--- a/testing/globalSetup.ts
+++ b/testing/globalSetup.ts
@@ -35,9 +35,9 @@ export async function setup() {
 
   // configure the code to use a local blank instance of blockchain
   blockchainContainer = await new GenericContainer(
-    'kiltprotocol/mashnet-node:latest',
+    'kiltprotocol/standalone-node:latest',
   )
-    .withCommand(['--dev', `--ws-port=${WS_PORT}`, '--ws-external'])
+    .withCommand(['--dev', `--rpc-port=${WS_PORT}`, '--rpc-external'])
     .withExposedPorts(WS_PORT)
     .withWaitStrategy(Wait.forLogMessage(`:${WS_PORT}`))
     .start();


### PR DESCRIPTION
Bumps kiltprotocol and polkadot dependencies to ensure we can still query DIDs and submit transactions on peregrine.